### PR TITLE
CI: use latest-stable Xcode in the parity job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      # Match the SPM jobs' toolchain: the Liquid Glass surface style references the
+      # macOS 26 SDK (`Glass` / `.glassEffect`), which only `latest-stable` carries -
+      # the runner's default Xcode does not, so the parity build fails without this.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Install XcodeGen
         run: brew install xcodegen
       - name: Regenerate project from project.yml


### PR DESCRIPTION
The Xcode parity job built with the runner's default Xcode, which lacks the macOS 26 SDK the Liquid Glass surface style needs (Glass / .glassEffect), failing with 'cannot find Glass in scope'. main has been red since the Liquid Glass commits. Select latest-stable - the same toolchain the SwiftPM jobs already use and pass on.