### PR TITLE
Build on Xcode before 26; clear a Swift 6 concurrency warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `#if compiler(>=6.2)`, so an earlier toolchain compiles the pre-Tahoe
   approximation instead of failing with "cannot find 'Glass' in scope"; on
   macOS 26 the real material is still used at runtime.
+- Cleared a Swift 6 concurrency warning on `NookFilePickerKey.defaultValue` (a
+  `@MainActor`-isolated value held in a nonisolated static): the inert default
+  picker now has a `nonisolated init`. No behavior change.
 
 ## [0.3.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Liquid Glass surface style now builds on Xcode versions earlier than 26.
+  Its `Glass` / `.glassEffect` use (the macOS 26 SDK) is compile-gated behind
+  `#if compiler(>=6.2)`, so an earlier toolchain compiles the pre-Tahoe
+  approximation instead of failing with "cannot find 'Glass' in scope"; on
+  macOS 26 the real material is still used at runtime.
+
 ## [0.3.0] - 2026-06-12
 
 The chrome-customization release. v0.3.0 opens up the framework chrome through

--- a/Sources/NookKit/App/NookFilePicker.swift
+++ b/Sources/NookKit/App/NookFilePicker.swift
@@ -330,12 +330,19 @@ public final class NookFilePicker: NookFilePresenting {
 /// never hold the surface. Module tests can register their own ``NookFilePresenting``
 /// fake against this key, since `NSOpenPanel` cannot run headless.
 public struct NookFilePickerKey: ServiceKey {
-    public static let defaultValue: any NookFilePresenting = UnregisteredFilePicker()
+    // `ServiceKey.defaultValue` is a nonisolated static, but `any NookFilePresenting` is
+    // @MainActor-isolated. `nonisolated(unsafe)` is sound here: the default is an inert,
+    // immutable singleton (it only asserts and returns nil), so reading this reference from
+    // any isolation is safe - calling its @MainActor methods stays gated by the protocol.
+    public nonisolated(unsafe) static let defaultValue: any NookFilePresenting = UnregisteredFilePicker()
 }
 
 /// Inert stand-in used as ``NookFilePickerKey``'s default. Never presents anything.
 private struct UnregisteredFilePicker: NookFilePresenting {
-    init() {}
+    // Nonisolated so the nonisolated `NookFilePickerKey.defaultValue` static can construct
+    // it: the type infers @MainActor from the protocol, but an empty inert value needs no
+    // isolation to build. The @MainActor `open`/`save` witnesses below are unaffected.
+    nonisolated init() {}
 
     func open(_ options: NookOpenOptions) async -> NookFileSelection? {
         assertionFailure(

--- a/Sources/NookSurface/Internal/NookView.swift
+++ b/Sources/NookSurface/Internal/NookView.swift
@@ -178,13 +178,24 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// outline stay in register.
     @ViewBuilder
     private func liquidGlassBackdrop(_ glass: NookBackdrop.LiquidGlass) -> some View {
+        // `Glass` / `.glassEffect` exist only in the macOS 26 SDK (Xcode 26+, Swift 6.2).
+        // `@available` is a runtime gate and still needs those symbols present in the SDK
+        // being compiled against, so an older Xcode cannot build the real path at all.
+        // Gate it at compile time too: an older toolchain uses the approximation
+        // unconditionally, while the macOS 26 SDK keeps the real material (runtime-gated
+        // to macOS 26). This lets a consumer on an earlier Xcode still build the package.
+        #if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             realLiquidGlass(glass)
         } else {
             approximateLiquidGlass(glass)
         }
+        #else
+        approximateLiquidGlass(glass)
+        #endif
     }
 
+    #if compiler(>=6.2)
     @available(macOS 26.0, *)
     @ViewBuilder
     private func realLiquidGlass(_ glass: NookBackdrop.LiquidGlass) -> some View {
@@ -198,6 +209,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
             // darken of its own on top of Apple's self-contrasting material.
             .overlay { glassShading(glass) }
     }
+    #endif
 
     /// The host-supplied legibility shading, rendered as a gradient. `nil` shading draws
     /// nothing, leaving the glass pristine. The gradient, its stops, and its direction all


### PR DESCRIPTION
Two robustness fixes.

1. Compile-gate the Liquid Glass path. `Glass` / `.glassEffect` only exist in the macOS 26 SDK, so building OpenNook on an earlier Xcode failed with 'cannot find Glass in scope' - the @available check is a runtime gate and still needs the symbols in the SDK. Gated behind #if compiler(>=6.2): earlier toolchains compile the pre-Tahoe approximation; macOS 26 still gets the real material at runtime. Verified by forcing the gate off and building clean.

2. Clear a Swift 6 concurrency warning on NookFilePickerKey.defaultValue (a @MainActor value in a nonisolated static) by giving the inert default picker a nonisolated init.

Build + 268 tests pass; no remaining concurrency warnings.