### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-12
+
 ### Fixed
 
 - The Liquid Glass surface style now builds on Xcode versions earlier than 26.
@@ -124,7 +126,8 @@ GitHub.
 Initial public release. See the
 [v0.1.0 release](https://github.com/glendonC/opennook/releases) on GitHub.
 
-[Unreleased]: https://github.com/glendonC/opennook/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/glendonC/opennook/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/glendonC/opennook/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/glendonC/opennook/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/glendonC/opennook/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/glendonC/opennook/releases/tag/v0.1.0


### PR DESCRIPTION
Patch release. Fixes: OpenNook builds on Xcode before 26 (the Liquid Glass macOS 26 SDK use is compile-gated behind #if compiler(>=6.2), falling back to the approximation), and a Swift 6 concurrency warning on NookFilePickerKey.defaultValue is cleared. Also stabilizes the flaky layout-grace refresh test.