### PR TITLE
Docs: surface materials, chrome customization, examples, breadcrumb/file pickers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,15 +75,33 @@ companion, not a dumping ground. Each example demonstrates **one** concept
 and uses **only the public API** (no `@testable`, no module-internal
 reaches). If a concept needs a new example, propose it in an issue.
 
+## Documentation
+
+The docs site lives in `site/src/content/docs/` (Astro Starlight, MDX). When you
+add or change public API, update the docs in the same change:
+
+- Add or update the relevant guide under `site/src/content/docs/guides/`, and
+  wire any new page into the sidebar in `site/astro.config.mjs`.
+- Add a `CHANGELOG.md` entry under `## [Unreleased]`.
+- Keep prose ASCII-only - hyphens (` - `), straight quotes, three dots for an
+  ellipsis - and match the surrounding guides' style.
+- A new public symbol still needs its DocC comment in source (see Public API
+  discipline above); the guides are the prose layer on top.
+
+Treat a feature as unfinished until its docs land. The site lagging the code is
+the failure mode this section exists to prevent.
+
 ## Submitting a change
 
 1. Branch off `main` (don't commit on `main` directly).
 2. Make the change. Run `swift build && swift test` locally.
-3. If you touched `Sources/NookSurface/` or added/removed Swift files,
+3. If you added or changed public API, add a `CHANGELOG.md` entry and update
+   the docs site (see [Documentation](#documentation)).
+4. If you touched `Sources/NookSurface/` or added/removed Swift files,
    verify the license-header job locally:
    `grep -L 'SPDX-License-Identifier' $(find Sources Tests Examples App -name '*.swift')`
    should print nothing.
-4. Open a PR using the template. CI must be green before review.
+5. Open a PR using the template. CI must be green before review.
 
 ## License
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -60,14 +60,17 @@ export default defineConfig({
             { label: 'Introduction', slug: 'start/introduction' },
             { label: 'Install', slug: 'start/install' },
             { label: 'Your first nook', slug: 'start/first-nook' },
+            { label: 'Examples', slug: 'guides/examples' },
           ],
         },
         {
           label: 'Customization',
           items: [
             { label: 'Theming', slug: 'guides/theming' },
+            { label: 'Surface materials', slug: 'guides/surface-materials' },
             { label: 'Layout and content insets', slug: 'guides/layout-and-insets' },
             { label: 'Settings chrome', slug: 'guides/settings-chrome' },
+            { label: 'Chrome customization', slug: 'guides/chrome-customization' },
             { label: 'Displays and presentation', slug: 'guides/displays' },
           ],
         },

--- a/site/src/content/docs/guides/chrome-customization.mdx
+++ b/site/src/content/docs/guides/chrome-customization.mdx
@@ -1,0 +1,373 @@
+---
+title: Chrome customization
+description: The additive NookConfiguration seams for launch defaults, chrome behavior, labels, branding, trailing items, and the status banner
+---
+
+[Theming](/guides/theming/) paints the chrome palette and [Settings
+chrome](/guides/settings-chrome/) toggles the top bar. This guide covers the
+rest of `NookConfiguration` - the deeper seams a host reaches for when it wants
+to ship its own out-of-box look, retune the chrome's behavior and motion, or
+brand the framework's identity.
+
+Every seam here is **additive and non-breaking**: each one defaults to a value
+that reproduces the framework exactly, so a plain `NookApp.main { MyHomeView() }`
+is unchanged. You opt in only where you need to. None of these are required to
+ship a working notch app.
+
+The working example for everything below is `Examples/ChromeNook/main.swift`.
+
+## When to reach for these
+
+- **Ship a non-default out-of-box look.** A host that should launch translucent,
+  dark, or floating - before the user ever opens Settings - seeds that through
+  `preferenceDefaults`.
+- **Change how the chrome behaves, not how it looks.** Hover side-effects, the
+  cold-launch greeting, and the appearance-to-backdrop mapping live on
+  `chromeBehavior`.
+- **Localize or rename chrome strings, or retune its fixed layout / springs.**
+  `labels`, `metrics`, and `motion` cover those.
+- **Brand the framework's identity.** Name the product, swap the brand mark, or
+  drop the menu-bar item through `branding` and `showsMenuBarExtra`.
+- **Add top-bar actions or post status.** `setTopBarTrailingItems` plants host
+  glyphs in the top bar; `AppState.showStatus` drives the framework banner.
+
+## Launch defaults: `preferenceDefaults`
+
+The process-global preferences - appearance (palette / surface style /
+presentation / haptics / keep-open), the global show/hide `NookHotkey`, and the
+`NookDisplayPreference` - normally start from framework defaults until the user
+changes them in Settings. `preferenceDefaults` reseeds those starting values, so
+a host can launch with its own look and shortcut without the user opening
+Settings first.
+
+These are **seed values, not overrides**. The moment the user changes one of
+them at runtime, that change is persisted and always wins; a seed value is
+**never written** to `UserDefaults`. That distinction matters: revising a default
+in a later build still reaches every user who never touched that setting, instead
+of being shadowed by a stale persisted copy.
+
+```swift
+configuration.preferenceDefaults = NookPreferenceDefaults(
+    appearance: NookAppearancePreferences(
+        chromePalette: .followSystem,
+        surfaceStyle: .translucent,
+        presentation: .auto
+    )
+)
+```
+
+`NookPreferenceDefaults` carries three fields, each with a default that
+reproduces the framework:
+
+```swift
+public struct NookPreferenceDefaults: Sendable, Equatable {
+    public var appearance: NookAppearancePreferences  // default .default
+    public var hotkey: NookHotkey                      // default .default (cmd-opt-;)
+    public var display: NookDisplayPreference          // default .builtIn
+}
+```
+
+Seed a different launch shortcut and display target the same way:
+
+```swift
+configuration.preferenceDefaults = NookPreferenceDefaults(
+    hotkey: NookHotkey(keyCode: 49, carbonModifiers: 4096 | 2048, keySymbol: "Space"),
+    display: .main   // launch on whichever screen hosts the active menu bar
+)
+```
+
+On the single-module path this `NookConfiguration.preferenceDefaults` is
+forwarded onto the synthesized host; a multi-module host sets the same value on
+`NookHostConfiguration.preferenceDefaults` (see [Multiple
+modules](/guides/multiple-modules/)). Because there is one `AppState` per
+process, these are host-process-global either way.
+
+## Chrome behavior: `NookChromeBehavior`
+
+`chromeBehavior` describes how the single shared surface *behaves* - distinct
+from the per-surface content and theme seams. It carries three knobs, each
+defaulting to today's framework behavior:
+
+```swift
+configuration.chromeBehavior = NookChromeBehavior(
+    hoverBehavior: .all,         // default []: opt into hover side-effects
+    showsLaunchShimmer: false,   // default true: launch silently
+    backdrop: { preferences, scheme, reduceTransparency in
+        .vibrancy(.init(material: .hudWindow, darkenOpacity: 0.3))
+    }
+)
+```
+
+### Hover behavior
+
+`hoverBehavior` is a `NookHoverBehavior` option set, empty by default - the
+framework applies no hover side-effects out of the box. Opt into either or both:
+
+```swift
+public struct NookHoverBehavior: OptionSet, Sendable {
+    public static let keepVisible    // hover keeps the surface visible past hide
+    public static let hapticFeedback // a subtle alignment haptic on hover transitions
+    public static let all            // [.keepVisible, .hapticFeedback]
+}
+```
+
+Read once when the surface is built, like `style`.
+
+### Launch shimmer
+
+`showsLaunchShimmer` defaults to `true` - the one-shot perimeter shimmer that
+plays at cold launch. Set it to `false` for a silent launch; the chrome still
+settles into its compact launch state, it just skips the feedback flourish.
+
+### Backdrop resolver
+
+`backdrop` overrides how appearance preferences map to the surface backdrop.
+`nil` (the default) uses the framework mapping - solid black or white for `.solid`
+or Reduce Transparency, otherwise a `.sidebar` vibrancy with a legibility darken.
+Supply a resolver to paint a brand-specific material, darken, or solid color
+while still reacting to the live appearance state:
+
+```swift
+public typealias BackdropResolver =
+    @Sendable @MainActor (NookAppearancePreferences, ColorScheme, Bool) -> NookBackdrop
+```
+
+The resolver receives the current `NookAppearancePreferences`, the effective
+`ColorScheme` (after the host's palette override and the system scheme), and
+whether Reduce Transparency is on. It returns a `NookBackdrop` - one of
+`.vibrancy(_:)`, `.solid(_:)`, or `.liquidGlass(_:)`. This closure, not any
+configuration struct, is where brand-tinted glass or a custom material lives:
+
+```swift
+configuration.chromeBehavior = NookChromeBehavior(
+    backdrop: { preferences, scheme, reduceTransparency in
+        if reduceTransparency || preferences.surfaceStyle == .solid {
+            return .solid(scheme == .dark ? .black : .white)
+        }
+        return .liquidGlass(.init(tint: .indigo, tintStrength: 0.22))
+    }
+)
+```
+
+`NookChromeBehavior` is not `Equatable` because `backdrop` carries a closure.
+Like `preferenceDefaults`, it is host-process-global: a single-module host sets
+it on `NookConfiguration`; a multi-module host sets it on
+`NookHostConfiguration.chromeBehavior`.
+
+## Labels, metrics, motion
+
+Three small value types tune the chrome's strings, fixed layout values, and
+in-panel springs. Each defaults to a value that reproduces today's framework
+exactly, and each reaches the views through a chrome environment value, so a host
+sets only the fields it cares about.
+
+### Labels
+
+`NookChromeLabels` holds the strings the chrome renders - for localization or
+product naming (for example "Preferences" instead of "Settings"):
+
+```swift
+configuration.labels.settingsBreadcrumb = "Preferences"
+configuration.labels.keepOpenHelp = "Stay expanded after hover"
+configuration.labels.settingsHelp = "Settings"
+configuration.labels.dismissHelp = "Dismiss"
+```
+
+`settingsBreadcrumb` is the label after the leading cluster
+(`[icon] Title > Settings`); the other three are tooltips on the keep-open lock,
+the gear, and the banner's dismiss button.
+
+### Metrics
+
+`NookChromeMetrics` exposes the few fixed point values that were previously baked
+into the views. Defaults reproduce today's layout:
+
+```swift
+configuration.metrics.edgePadding = 8          // panel edge to content inset
+configuration.metrics.compactSlotSize = 24     // square size of each compact pill slot
+configuration.metrics.breadcrumbMaxWidth = 140 // top-bar breadcrumb width before it fades
+configuration.metrics.topBarHeight = 24        // fixed height of the top bar icon row
+```
+
+`edgePadding` is distinct from `NookStyle.expandedContentInsets`; host home views
+should read the residual clearance through `nookContentInsets` rather than
+mirroring it with extra padding. See [Layout and content
+insets](/guides/layout-and-insets/) and `Examples/LayoutNook/main.swift`.
+
+### Motion
+
+`NookChromeMotion` retunes the chrome's *in-panel* animation curves - distinct
+from `NookConfiguration.transitions`, which governs the surface-level
+expand / collapse / compact conversion. These drive the home-to-Settings swap,
+the status banner, the breadcrumb, and the leading cluster's reveals:
+
+```swift
+configuration.motion.viewModeChange = .snappy        // home<->Settings swap and gear toggle
+configuration.motion.leadingClusterBack = .snappy    // exiting Settings / clearing a breadcrumb
+configuration.motion.leadingClusterHover = .snappy   // hover-reveal of the title
+configuration.motion.statusBanner = .snappy          // banner appearance / dismissal
+configuration.motion.breadcrumb = .easeOut(duration: 0.18)
+```
+
+## Identity: branding, brand mark, menu-bar
+
+`NookHostBranding` names the host *product* and supplies its brand mark - the
+identity the chrome labels itself with. The About card reads `hostName` and
+`hostTagline`; the show/hide hotkey label and the menu-bar fallback read
+`hostName`; the `mark` closure replaces the OpenNook glyph everywhere the chrome
+draws it (the top-bar leading cluster when no `leadingIcon` is set, the About
+card, and the menu-bar status icon).
+
+```swift
+configuration.branding = NookHostBranding(
+    hostName: "ContextNook",
+    hostTagline: "A focused notch app.",
+    mark: { size, color in AnyView(MyMark(color: color).frame(width: size, height: size)) }
+)
+```
+
+The brand mark is a `NookBrandMark` closure - `@Sendable @MainActor (size, color)
+-> AnyView`. It is handed a point size and the resolved tint, and the host returns
+any SwiftUI view sized to fit. A minimal mark from `Examples/ChromeNook/main.swift`:
+
+```swift
+struct SparkMark: View {
+    var color: Color
+    var body: some View {
+        Image(systemName: "sparkle")
+            .resizable()
+            .scaledToFit()
+            .foregroundStyle(color)
+    }
+}
+```
+
+`hostTagline` is optional; leaving it `nil` falls back to the framework's stock
+line describing the host as built with OpenNook. Leaving `mark` `nil` keeps the
+OpenNook `NookMarkView` - the minimal notch arc plus center dot. `NookHostBranding`
+is `Equatable` on its strings only (a closure can't be compared), so two brandings
+are equal when their `hostName` and `hostTagline` match.
+
+To turn the framework's menu-bar item off entirely - for a host that owns its own
+menu-bar presence or wants none - set `showsMenuBarExtra`:
+
+```swift
+configuration.showsMenuBarExtra = false
+```
+
+This drops the "Show ..." / Settings / Quit fallback the framework otherwise
+installs. Like the other host-level seams, on the single-module path
+`branding` and `showsMenuBarExtra` forward onto the synthesized host; a
+multi-module host sets `branding` on `NookHostConfiguration` directly (see the
+[host branding](/guides/multiple-modules/#host-branding) section).
+
+## Top-bar trailing items
+
+`setTopBarTrailingItems` registers host actions for the top bar's trailing
+cluster. They render immediately to the left of the framework's keep-open lock
+and gear, so the order reads host items, then lock, then gear. The items render
+inside the same chrome environment as the rest of the top bar, so they can
+observe `AppState` via `@EnvironmentObject` and read the palette via
+`@Environment(\.nookResolvedTheme)`:
+
+```swift
+configuration.setTopBarTrailingItems { ChromeTrailingActions() }
+
+struct ChromeTrailingActions: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.nookResolvedTheme) private var theme
+
+    var body: some View {
+        Button {
+            appState.showStatus("Heads up - warning posted from the top bar.",
+                                 severity: .warning)
+        } label: {
+            Image(systemName: "bell")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(theme.headerInactiveIcon)
+                .frame(width: 24, height: 24)
+        }
+        .buttonStyle(.plain)
+        .help("Post a warning status")
+    }
+}
+```
+
+Space is tight. The top bar runs *under* the physical notch on a notched display,
+so anything between the notch's edges is hardware-clipped, and the trailing
+cluster has only roughly 80-100pt of usable width at the 480-520pt expanded
+widths. Keep these to compact glyph-style buttons matching the lock and gear
+weight - not wide labeled pills. Leaving `trailingItems` unset reproduces the
+framework chrome exactly: just the lock and gear.
+
+## Top-bar width: `.contentColumn`
+
+`topBar.width` controls how the icon row spans the expanded content column. It
+defaults to `.contentColumn`, which is usually what you want:
+
+```swift
+public enum Width: Sendable, Equatable {
+    case contentColumn  // default
+    case intrinsic
+}
+```
+
+- `.contentColumn` (the default) gives the leading and trailing clusters the full
+  column width, aligning trailing icons to the same `nookContentInsets` gutter on
+  the right that host home rows use. This is what makes your trailing items line
+  up with content below them.
+- `.intrinsic` reproduces the legacy shrink-wrapped bar: the clusters shrink to
+  their icons and center when narrower than the column.
+
+```swift
+configuration.topBar.width = .intrinsic  // opt out of the content-column alignment
+```
+
+## Status banner
+
+The framework renders a transient status banner under the top bar, driven by
+`AppState.status`. Post to it from any `AppState` handle with `showStatus`:
+
+```swift
+public func showStatus(_ message: String, severity: NookStatusSeverity = .error)
+```
+
+`NookStatusSeverity` has four cases - `.error`, `.warning`, `.info`, `.success` -
+each selecting the banner's SF Symbol (an error reads differently from a success).
+The framework keeps the banner on its minimal palette: the glyph is tinted with
+the resolved theme's accent rather than inventing semantic red/green tokens, and
+the severity distinction is carried by the symbol. A host that wants colored
+severity supplies its own banner content or theme.
+
+```swift
+appState.showStatus("Imported 3 files", severity: .success)
+appState.showStatus("Could not reach the server", severity: .error)
+```
+
+The status is tied to a single nook session - it is cleared on the next
+show/toggle, or by the banner's dismiss button. (Durable failures, like a failed
+hotkey registration, use a separate channel so they outlive the session.)
+
+To suppress the framework banner - for a host that surfaces status inside its own
+home content - turn it off:
+
+```swift
+configuration.topBar.showsStatusBanner = false  // default true
+```
+
+`showStatus` still updates `AppState.status` either way, so a host that renders
+its own banner can read the message and severity directly from
+`@EnvironmentObject var appState`.
+
+## See also
+
+- `Examples/ChromeNook/main.swift` - the working example this guide mirrors:
+  launch defaults, chrome behavior, labels/metrics/motion, a custom brand mark,
+  trailing items, and the status banner in one host.
+- [Settings chrome](/guides/settings-chrome/) - the top-bar visibility flags
+  (`showsTopBar`, `showsSettings`) and the leading cluster.
+- [Theming](/guides/theming/) - the chrome palette, `accent`, and `fontDesign`
+  that these seams render against.
+- [Multiple modules](/guides/multiple-modules/) - where `preferenceDefaults`,
+  `chromeBehavior`, and `branding` live on `NookHostConfiguration` for a
+  multi-module host.

--- a/site/src/content/docs/guides/examples.mdx
+++ b/site/src/content/docs/guides/examples.mdx
@@ -1,0 +1,73 @@
+---
+title: Examples
+description: An index of the nine single-file example apps under Examples/, each linked to the guide that covers it
+---
+
+Every example under `Examples/` is a single-file host that builds on OpenNook's
+public API only - no forking, no patched framework. Each one is its own SPM
+target, so you run it straight from the repo with `swift run <Name>` and press
+the show/hide hotkey (the default is the option-command-semicolon combination)
+to expand the nook.
+
+They are grouped here so you can jump to the one closest to what you are
+building. Each entry links to the guide that explains the concept in full.
+
+## Getting started
+
+The smallest hosts - one view, or one view plus a compact-slot glyph. Start
+here if you have never run an OpenNook app.
+
+- **HelloNook** - `swift run HelloNook`. The smallest possible app: hand
+  `NookApp.main` one SwiftUI view and the top bar, Settings, hotkey, and compact
+  pill all come for free. See [Your first nook](/start/first-nook/).
+- **ClockNook** - `swift run ClockNook`. A live-clock home surface plus a custom
+  compact glyph, showing the `setHome` and `setCompactTrailing` registration
+  knobs side by side. See [Your first nook](/start/first-nook/).
+
+## Customization
+
+Reshaping the chrome - palette, lifecycle hooks, brand mark, layout - through
+`NookConfiguration`.
+
+- **ThemedNook** - `swift run ThemedNook`. A host-supplied `NookResolvedTheme`
+  that paints the chrome labels, plus the `onExpand` / `onCompact` lifecycle
+  callbacks. See [Theming](/guides/theming/).
+- **ChromeNook** - `swift run ChromeNook`. A tour of the deeper chrome seams:
+  launch-preference defaults, hover and backdrop behavior, label and metric
+  overrides, a custom brand mark, top-bar trailing actions, and the status
+  banner. See [Chrome customization](/guides/chrome-customization/).
+- **LayoutNook** - `swift run LayoutNook`. The recommended expanded-width and
+  content-inset patterns - how a home view reads `\.nookContentInsets` instead
+  of adding its own horizontal padding. See
+  [Layout and content insets](/guides/layout-and-insets/).
+
+## Components
+
+Drop-in surfaces from the `NookComponents` add-on. Each imports
+`NookComponents` alongside `NookApp`.
+
+- **ShelfNook** - `swift run ShelfNook`. A file shelf in the notch: drag files
+  on to collect them, drag them back out to Finder, persisted across launches.
+  See [File shelf](/guides/file-shelf/).
+- **ActivityNook** - `swift run ActivityNook`. A `NookActivityQueue` that
+  collects transient activities and briefly takes over the expanded surface for
+  each, one at a time. See [Activity queue](/guides/activity-queue/).
+- **VolumeNook** - `swift run VolumeNook`. An ambient volume glyph in the
+  compact pill - a `SystemVolumeObserver` tracks the output level and
+  `NookVolumeIndicator` renders it beside the notch. See
+  [Volume glyph](/guides/volume-glyph/).
+
+## Hosting
+
+Running more than one notch app in a single process.
+
+- **MultiNook** - `swift run MultiNook`. One host process with several
+  interchangeable modules sharing one surface, switched through the menu bar,
+  the cycle hotkey, or an in-surface switcher. See
+  [Multiple modules](/guides/multiple-modules/).
+
+## See also
+
+- The `Examples/` directory in the repository - the source for every app above.
+- [Your first nook](/start/first-nook/) - the walkthrough HelloNook and
+  ClockNook accompany.

--- a/site/src/content/docs/guides/multiple-modules.mdx
+++ b/site/src/content/docs/guides/multiple-modules.mdx
@@ -78,6 +78,55 @@ host.moduleSwitcherPlacement = .menuBar        // default
 - `.none` - no on-screen switcher anywhere. Switching is reachable only through
   the hotkeys.
 
+## Module drill-in breadcrumb
+
+The switcher names the active *module*; `AppState.moduleBreadcrumb` names where
+the user is *inside* it. When a module drills into a sub-screen - a selected
+deck, an open document, a chosen profile - set `moduleBreadcrumb` to a short
+label and the top bar renders it after the leading title as
+`[icon] Module  >  Breadcrumb`, so the chrome reflects what the user is actually
+looking at instead of the module's static name. Set it back to `nil` to clear.
+
+```swift
+struct DeckList: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        ForEach(decks) { deck in
+            Button(deck.name) {
+                openDeck(deck)
+                appState.moduleBreadcrumb = deck.name   // drilled in
+            }
+        }
+    }
+}
+```
+
+Pushing a breadcrumb changes one thing in the chrome beyond the label: the
+leading glyph stops being a static module mark and becomes a back control. On
+home with no breadcrumb the title sits next to its icon; once a breadcrumb is
+set the persistent title collapses and the glyph - now a `chevron.left` when the
+module has no leading icon - clears `moduleBreadcrumb` when tapped. The
+framework only clears the property; it does not touch the module's own
+navigation. The module observes the clear and pops its own sub-state:
+
+```swift
+.onChange(of: appState.moduleBreadcrumb) { _, breadcrumb in
+    if breadcrumb == nil {
+        popToRoot()   // the chrome's back tap cleared it; mirror that here
+    }
+}
+```
+
+This is a soft state hint, not a view-mode change. It does not affect
+`AppState.viewMode` or the home/Settings routing - a breadcrumb can be set while
+the home view is showing, and entering Settings takes over the same leading slot
+with its own breadcrumb until the user backs out. The label is constrained to
+the pre-notch region: it is capped at `metrics.breadcrumbMaxWidth` (see
+[Theming](/guides/theming/) for the chrome `metrics` knobs) and fades out at its
+trailing edge rather than overrunning the notch, so a long sub-context label
+never collides with the camera housing. Keep the labels short for that reason.
+
 ## Descriptors and modules
 
 A module has two parts: a cheap **descriptor** (the identity the switcher and
@@ -207,6 +256,73 @@ process-global container.
 Register a key once per construction. The double-register guard traps in
 debug; in release the last writer wins. If you genuinely need to replace a
 service later, use the subscript form (`services[Key.self] = newValue`).
+
+## File pickers from a module
+
+A module that imports or exports files should not roll its own `NSOpenPanel`.
+The host is an agent app (`LSUIElement`) whose only window is a non-activating
+panel, so at the moment a module asks for a file the app is *inactive*: a panel
+presented by an inactive agent comes up non-key, can appear behind the frontmost
+app, and its sidebar stops responding to clicks. The host owns the fix once and
+hands every module a ready picker through services.
+
+`NookFilePicker` is registered into every module's `AppServices` automatically
+when its context is built - alongside the presentation-pinning broker - so you
+never wire it yourself. Resolve it from the `\.appServices` environment via
+`NookFilePickerKey` and call `open` or `save`:
+
+```swift
+struct ImportButton: View {
+    @Environment(\.appServices) private var services
+
+    var body: some View {
+        Button("Import") {
+            let picker = services.resolve(NookFilePickerKey.self)
+            Task {
+                guard let selection = await picker.open(
+                    .init(allowedContentTypes: [.pdf], allowsMultipleSelection: true)
+                ) else { return }
+                selection.withAccess { urls in store.accept(urls) }
+            }
+        }
+    }
+}
+```
+
+Both `open(_:)` and `save(_:)` are `async` and return a `NookFileSelection?` -
+`nil` when the user cancels or a panel is already up (only one panel is
+presented at a time). `open` takes `NookOpenOptions`; `save` takes
+`NookSaveOptions`. The picker does two things a hand-rolled panel cannot:
+
+- **It activates the app before presenting,** so the panel comes up key and
+  interactive even though the click on the notch never activated the agent.
+- **It holds the surface open for the panel's whole lifetime.** A picker is a
+  separate AppKit panel outside the notch window, so while it is up the pointer
+  has left the notch; without a pin the surface would auto-compact and a
+  competing module's arbiter claim could be granted underneath. The picker pins
+  the surface for the panel's lifetime and releases the pin once it closes -
+  the same pin a module's own transient presenter would take.
+
+A panel-returned URL comes back already security-scoped. The `NookFileSelection`
+owns that live access and stops it when the selection is released, so read the
+file's contents - or capture a `.withSecurityScope` bookmark to persist access
+across launches - inside `withAccess(_:)` while the selection is still alive.
+After it is released the URLs are path-level only and reads fail under the
+sandbox.
+
+> **Sandbox caveat.** Under the App Sandbox, the
+> `com.apple.security.files.user-selected.read-write` entitlement is what makes a
+> picked file readable - ship it (the host's entitlements template has it). And
+> under `swift run` the binary is unbundled and unsandboxed with no powerbox, so
+> the panel cannot enter TCC-protected folders (Downloads, Desktop, Documents);
+> run the signed `.app` or grant your terminal Full Disk Access. That is a
+> dev-loop artifact, not a shipping limitation. See [Shipping](/guides/shipping/)
+> for the full entitlement list.
+
+For module tests, register your own `NookFilePresenting` fake against
+`NookFilePickerKey` - `NSOpenPanel` cannot run headless, and the key's default
+value is a deliberately inert picker that traps in debug if it is ever resolved
+without the host registration.
 
 ## The module-switch lifecycle
 

--- a/site/src/content/docs/guides/surface-materials.mdx
+++ b/site/src/content/docs/guides/surface-materials.mdx
@@ -1,0 +1,176 @@
+---
+title: Surface materials
+description: Pick the material the chrome paints behind nook content - solid, translucent, or Liquid Glass
+---
+
+A *surface style* decides what the chrome paints behind compact and expanded
+nook content: a flat opaque panel, a frosted vibrancy material, or Apple's
+Liquid Glass. It is a user-facing preference - the framework ships a Settings
+control for it and persists the choice - so most hosts never set it in code;
+they read the resolved value back to pick a matching palette.
+
+## Where the style is picked
+
+The style lives on `NookAppearancePreferences.surfaceStyle`:
+
+```swift
+public enum NookSurfaceStyle: String, Codable, Sendable, CaseIterable {
+    case solid        // opaque panel, matches the menu-bar notch (the default)
+    case translucent  // frosted vibrancy material, shows the wallpaper
+    case liquidGlass  // Apple's Liquid Glass material (macOS 26+)
+}
+```
+
+`surfaceStyle` defaults to `.solid`. The framework owns the Settings panel that
+writes it - the Appearance screen renders a segmented "Surface" picker (Solid /
+Translucent / Liquid Glass) and persists the selection through
+`AppState.replaceAppearancePreferences(_:)`. Your code reads from it; see [how a
+host reads the style](#read-the-style-to-pick-a-palette) below.
+
+To ship a non-default out of the box, seed it on
+`NookConfiguration.preferenceDefaults` (a seed the user can always override in
+Settings, never persisted on its own):
+
+```swift
+configuration.preferenceDefaults = NookPreferenceDefaults(
+    appearance: NookAppearancePreferences(surfaceStyle: .liquidGlass)
+)
+```
+
+## The three styles
+
+The mapping from a style to a concrete `NookBackdrop` lives in
+`NookBackdropMapping.notchBackdrop`, keyed by the style, the effective color
+scheme, and whether Reduce Transparency is on.
+
+- **`.solid`** paints a flat opaque fill - true black on dark chrome, true white
+  on light - so the expanded panel reads as one continuous surface with the
+  physical notch. No `NSVisualEffectView` is involved. This is the default and
+  the most legible over any wallpaper.
+- **`.translucent`** paints a frosted `NSVisualEffectView` sidebar material
+  sampling the wallpaper behind the window, with a legibility darken pass
+  composited on top. The darken scales with `backdropStrength` (the Settings
+  "Translucency strength" slider) so the user can let more wallpaper through.
+- **`.liquidGlass`** paints Apple's Liquid Glass material on macOS 26 (Tahoe)
+  and later, and a layered approximation on earlier systems. The default mapping
+  uses neutral, untinted glass - the real material refracts the wallpaper on its
+  own - with a light top-to-bottom darken so the surface reads glassier as it
+  nears the wallpaper.
+
+## Liquid Glass in depth
+
+Liquid Glass renders through `NookBackdrop.liquidGlass(LiquidGlass)`. The
+`LiquidGlass` spec carries four knobs that drive both render paths:
+
+```swift
+public struct LiquidGlass: Equatable, Sendable {
+    public var tint: Color?            // nil = neutral, clear glass (the default)
+    public var tintStrength: CGFloat   // 0...1, default 0.18; ignored when tint is nil
+    public var highlightStrength: CGFloat // 0...1 specular rim + sheen, default 0.6
+    public var shading: Shading?       // legibility gradient the caller fully owns
+}
+```
+
+`shading` is a `Gradient` plus a direction (`startPoint`/`endPoint`, defaulting
+top-to-bottom), so the legibility pass is entirely the caller's - the surface
+renders exactly what the spec carries and never substitutes its own. The default
+framework mapping supplies a sensible top-to-bottom darken; a host returning its
+own `.liquidGlass` from a backdrop resolver can replace it wholesale.
+
+### Real material vs the pre-Tahoe approximation
+
+The surface dispatches on availability. On macOS 26+ it draws the real system
+material; on macOS 15-25 it draws a layered approximation that reads as glass:
+
+- **Real material (macOS 26+).** A `Color.clear` painted with
+  `.glassEffect(_:in:)` using a `Glass` material, clipped to the same
+  `NookShape` the chrome already uses, with the host's `shading` overlaid on
+  top. A non-nil `tint` becomes `Glass.regular.tint(tint.opacity(tintStrength))`.
+  macOS supplies its own edge highlights here, so `highlightStrength` only adds a
+  faint extra rim.
+- **Approximation (macOS 15-25).** A glassy `NSVisualEffectView` (`.hudWindow`)
+  material, an optional tint overlay, the same `shading`, then the specular
+  treatment that actually sells the glass read: a top-down sheen and a bright rim
+  traced along `NookShape`. `highlightStrength` scales that sheen and rim.
+
+### Runtime gate and compile gate
+
+The real path is gated twice, and it matters for what you can build and where it
+runs:
+
+- **Runtime gate** - `@available(macOS 26.0, *)`: the real `.glassEffect`
+  material only renders on macOS 26 and later. On an older OS the surface falls
+  back to the approximation at runtime, so it cannot crash on systems without
+  the material.
+- **Compile gate** - `#if compiler(>=6.2)`: `Glass` and `.glassEffect` exist
+  only in the macOS 26 SDK (Xcode 26+, Swift 6.2). An `@available` check still
+  needs those symbols present in the SDK being compiled against, so an older
+  Xcode cannot build the real path at all. The compile gate routes an earlier
+  toolchain to the approximation unconditionally, so the package builds on Xcode
+  before 26 instead of failing with "cannot find 'Glass' in scope".
+
+Putting both together: the package always builds, on any supported Xcode. The
+real material needs the macOS 26 SDK (Xcode 26+) to build *and* macOS 26 at
+runtime to render. Anywhere else, `.liquidGlass` still works - it just draws the
+approximation.
+
+## Reduce Transparency
+
+When the user enables Reduce Transparency, the mapping collapses both
+translucent styles toward solid. `.translucent` and `.liquidGlass` both fall
+back to a flat opaque fill (black on dark, white on light) - neither the frosted
+material nor the glass renders when the user has opted out of translucency. The
+guard is a single check in `NookBackdropMapping.notchBackdrop`:
+
+```swift
+if preferences.surfaceStyle == .solid || reduceTransparency {
+    return .solid(isDark ? .black : .white)
+}
+```
+
+So a host palette never has to special-case Reduce Transparency for the surface
+material itself - the surface is already solid. (You may still want to nudge
+`subtleFill` for contrast on a true-solid panel; see the [Theming
+guide](/guides/theming/).)
+
+## Read the style to pick a palette
+
+A host that brands its chrome usually reads the chosen surface style and returns
+a matching `NookResolvedTheme`. Branch on
+`appState.appearancePreferences.surfaceStyle`:
+
+```swift
+configuration.theme = { appState in
+    switch appState.appearancePreferences.surfaceStyle {
+    case .solid:       return SolidPalette.resolve(appState)
+    case .translucent: return FrostPalette.resolve(appState)
+    case .liquidGlass: return GlassPalette.resolve(appState)
+    }
+}
+```
+
+The switch is exhaustive over all three cases, so adding a palette branch for
+`.liquidGlass` keeps it compiling. A glass-tuned palette typically leans on
+lighter fills and brighter labels, since the glass keeps its own contrast and
+needs less darken under chrome content than a frosted material does.
+
+To paint brand-tinted glass instead of reading it back, supply a `LiquidGlass`
+spec from a `NookChromeBehavior` backdrop resolver - that closure, not the
+Settings style, is where the deeper customization lives:
+
+```swift
+configuration.chromeBehavior = NookChromeBehavior(
+    backdrop: { preferences, scheme, reduceTransparency in
+        .liquidGlass(.init(tint: .blue, tintStrength: 0.22))
+    }
+)
+```
+
+## See also
+
+- [Theming](/guides/theming/) - the palette resolver and `NookResolvedTheme`
+  slots that pair with the surface material.
+- `Sources/NookSurface/NookBackdrop.swift` - the `NookBackdrop` and `LiquidGlass`
+  types, the source of truth for the knobs.
+- `Sources/NookKit/App/NookBackdropMapping.swift` - how a style, color scheme,
+  and Reduce Transparency map to a backdrop.

--- a/site/src/content/docs/guides/theming.mdx
+++ b/site/src/content/docs/guides/theming.mdx
@@ -180,8 +180,8 @@ NookApp.main(configuration)
 ```
 
 For how `expandedWidth`, `expandedContentInsets`, `metrics.edgePadding`, and
-`nookContentInsets` compose into usable content width — and how to avoid
-double horizontal padding on the home view — see
+`nookContentInsets` compose into usable content width - and how to avoid
+double horizontal padding on the home view - see
 [Layout and content insets](/guides/layout-and-insets/) and
 `Examples/LayoutNook/main.swift`.
 
@@ -207,7 +207,7 @@ from it.
 ```swift
 public struct NookAppearancePreferences: Equatable, Codable, Sendable {
     public var chromePalette: NookChromePalette   // .followSystem / .dark / .light
-    public var surfaceStyle: NookSurfaceStyle     // .solid / .translucent
+    public var surfaceStyle: NookSurfaceStyle     // .solid / .translucent / .liquidGlass
     public var presentation: NookPresentation     // .auto / fused / free-floating
     public var hapticFeedbackEnabled: Bool
     public var keepNookOpen: Bool
@@ -216,7 +216,8 @@ public struct NookAppearancePreferences: Equatable, Codable, Sendable {
 
 - `chromePalette` pins the chrome to dark / light or follows macOS.
 - `surfaceStyle` picks a solid panel that matches the menu-bar notch (the
-  default), or a translucent material that lets the wallpaper through.
+  default), a translucent material that lets the wallpaper through, or Liquid
+  Glass - see [Surface materials](/guides/surface-materials/).
 - `presentation` is `.auto` by default and is the knob that makes the chrome
   work on a Mac with no notch.
 
@@ -227,6 +228,7 @@ configuration.theme = { appState in
     switch appState.appearancePreferences.surfaceStyle {
     case .solid:       return SolidPalette.resolve(appState)
     case .translucent: return FrostPalette.resolve(appState)
+    case .liquidGlass: return GlassPalette.resolve(appState)
     }
 }
 ```


### PR DESCRIPTION
Brings the docs site current with the code and adds a guard so it stays that way.

New guides:
- Surface materials - the three NookSurfaceStyle backdrops, with Liquid Glass in depth (the real macOS 26 material vs the pre-Tahoe approximation, the runtime + compile gates, Reduce Transparency). Liquid Glass was previously undocumented anywhere on the site.
- Chrome customization - the deeper NookConfiguration seams with no prior site coverage: preference defaults, chrome behavior, labels/metrics/motion, branding and brand mark, top-bar trailing items, the .contentColumn width, and the status banner. Surfaces Examples/ChromeNook.
- Examples - an index of all nine example apps, grouped and cross-linked to their guides.

Updated:
- theming.mdx: fixed a stale NookSurfaceStyle (listed only .solid/.translucent; the example switch no longer compiled without .liquidGlass) and pointed to Surface materials.
- multiple-modules.mdx: added the drill-in breadcrumb (AppState.moduleBreadcrumb) and module file-picker (NookFilePicker) sections.
- astro.config.mjs: wired the new pages into the sidebar.

Process:
- CONTRIBUTING now requires docs + CHANGELOG updates alongside public-API changes.

Site builds clean (19 pages). Every API name in the snippets was verified against source; all prose is ASCII-only.