### PR TITLE
README cross-links + DocC generation and CI rot-guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,19 @@ jobs:
             exit 1
           fi
           echo "License headers OK."
+
+  docs:
+    name: DocC build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      # The Liquid Glass surface code references the macOS 26 SDK; match the other
+      # jobs so symbol extraction compiles the real path.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      # Builds the same DocC reference Swift Package Index publishes per release
+      # (.spi.yml), so a doc-comment change that breaks the build fails here at PR
+      # time instead of silently breaking the next release's hosted docs.
+      - name: Build the API reference
+        run: ./Scripts/generate-docs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@ xcuserdata/
 Nook.xcodeproj/
 .swiftpm/
 
+# Generated DocC output (Scripts/generate-docs.sh). The hosted API reference is
+# built by Swift Package Index from .spi.yml, so this never needs committing.
+.docs-out/
+
 # Internal planning notes — not part of the published framework.
 .notes/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,11 @@ add or change public API, update the docs in the same change:
 - A new public symbol still needs its DocC comment in source (see Public API
   discipline above); the guides are the prose layer on top.
 
+The symbol-level API reference is generated from those DocC comments by Swift
+Package Index (`.spi.yml`), not hand-written. Preview it locally with
+`./Scripts/generate-docs.sh`; CI builds it on every PR, so a doc comment that
+breaks DocC fails the build before it reaches the next release.
+
 Treat a feature as unfinished until its docs land. The site lagging the code is
 the failure mode this section exists to prevent.
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 5.9
 
+import Foundation
 import PackageDescription
 
 /// Centralized strict-concurrency checking — applied to every target so the
@@ -8,7 +9,7 @@ import PackageDescription
 /// concurrency rules the library targets enforce.
 let strictConcurrency: [SwiftSetting] = [.enableUpcomingFeature("StrictConcurrency")]
 
-let package = Package(
+var package = Package(
     name: "Nook",
     platforms: [
         .macOS("15.0")
@@ -153,3 +154,13 @@ let package = Package(
         )
     ]
 )
+
+// DocC is a docs-only, opt-in dependency: the swift-docc-plugin is added to the manifest
+// only when OPENNOOK_BUILD_DOCS is set, so consumers of OpenNook never resolve or fetch it
+// and the framework keeps its zero-runtime-dependency promise. Generate the API reference
+// with Scripts/generate-docs.sh (which sets the variable).
+if ProcessInfo.processInfo.environment["OPENNOOK_BUILD_DOCS"] != nil {
+    package.dependencies.append(
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+    )
+}

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ ship.
 
 `NookConfiguration` exposes the rest of the chrome through additive, non-breaking
 seams - every default reproduces the framework exactly, so you opt in only where
-you need to.
+you need to. The [Chrome customization guide](https://opennook.dev/guides/chrome-customization/)
+covers each seam in full; the headlines are below.
 
 **Launch defaults.** Ship your own out-of-box appearance, global hotkey, and
 display target. Seed-only: a value the user has changed in Settings always wins,
@@ -225,6 +226,11 @@ configuration.preferenceDefaults = NookPreferenceDefaults(
     )
 )
 ```
+
+`surfaceStyle` is `.solid`, `.translucent`, or `.liquidGlass` - the real macOS 26
+Liquid Glass material, with a pre-Tahoe approximation so the package still builds
+and runs on earlier systems. See
+[Surface materials](https://opennook.dev/guides/surface-materials/).
 
 **Chrome behavior.** Hover side-effects, the cold-launch shimmer, and the
 appearance→backdrop mapping:

--- a/Scripts/generate-docs.sh
+++ b/Scripts/generate-docs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# generate-docs.sh
+# Builds the OpenNook API reference as a combined, static-hostable DocC site from
+# the framework's own doc comments - the same documentation Swift Package Index
+# builds and hosts per release (the targets are pinned in .spi.yml).
+#
+# The swift-docc-plugin is an opt-in dependency: it is added to Package.swift only
+# when OPENNOOK_BUILD_DOCS is set (which this script does), so consumers of OpenNook
+# never resolve or fetch it.
+#
+# Usage:
+#   ./Scripts/generate-docs.sh [output-dir] [hosting-base-path]
+# Defaults: output-dir = ./.docs-out, hosting-base-path = opennook
+#
+# Preview locally after generating:
+#   (cd .docs-out && python3 -m http.server 8000)
+#   then open http://localhost:8000/opennook/documentation/nookapp/
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUTPUT_DIR="${1:-$PWD/.docs-out}"
+BASE_PATH="${2:-opennook}"
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+OPENNOOK_BUILD_DOCS=1 swift package \
+  --allow-writing-to-directory "$OUTPUT_DIR" \
+  generate-documentation \
+  --enable-experimental-combined-documentation \
+  --target NookApp \
+  --target NookKit \
+  --target NookSurface \
+  --target NookComponents \
+  --transform-for-static-hosting \
+  --hosting-base-path "$BASE_PATH" \
+  --output-path "$OUTPUT_DIR"
+
+echo
+echo "DocC site generated at: $OUTPUT_DIR (hosting-base-path: /$BASE_PATH)"

--- a/site/src/content/docs/reference/api.mdx
+++ b/site/src/content/docs/reference/api.mdx
@@ -13,6 +13,9 @@ The map below is the maintained index of the public surface, grouped by module,
 with the guide that teaches each piece and the source file that defines it. The
 source is always the source of truth.
 
+Build that DocC reference yourself with `./Scripts/generate-docs.sh` - it
+produces the same combined site Swift Package Index hosts.
+
 ## NookApp
 
 The one-line entry point. `import NookApp` re-exports `NookKit` and


### PR DESCRIPTION
Two follow-ups from the docs refresh.

README cross-links:
- Links the new Chrome customization and Surface materials guides from the README's Deeper chrome customization section, and adds a Liquid Glass note where surfaceStyle appears.

DocC API reference:
- The symbol-level reference is already auto-generated and hosted by Swift Package Index (.spi.yml), regenerated per release - so no hand-maintained reference to rot. What was missing was a guard so a doc-comment change that breaks the DocC build is caught at PR time, not on the next release.
- Adds swift-docc-plugin as an opt-in dependency (only resolved when OPENNOOK_BUILD_DOCS is set), so consumers never fetch it and the zero-runtime-dependency promise holds.
- Scripts/generate-docs.sh builds the same combined DocC site locally for preview.
- A new 'DocC build' CI job runs that generation on every PR/push, mirroring the Swift Package Index doc build.
- CONTRIBUTING documents the flow; api.mdx points at the local generator; .docs-out output is gitignored.

Verified: consumer build unaffected without the env var; the plugin resolves and the combined site builds for all four targets with the env var; site builds; all additions ASCII-clean.