### PR TITLE
Fix stale DocC references + ASCII typography in README/config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 # Runs the full build + test matrix on every push to main and every PR, plus a
 # license-header sanity check that pins the dual-license boundary
 # (Sources/NookSurface is MIT; everything else is Apache-2.0). The Xcode build
-# is included so the SPM ↔ Xcode parity README claim ("behavior cannot drift
+# is included so the SPM <-> Xcode parity README claim ("behavior cannot drift
 # between them") is actually verified.
 
 name: CI
@@ -23,7 +23,7 @@ jobs:
     name: SwiftPM build & test (Xcode ${{ matrix.xcode }})
     runs-on: macos-15
     strategy:
-      # One toolchain regression shouldn't cancel the others — we want to see the full
+      # One toolchain regression shouldn't cancel the others - we want to see the full
       # matrix result, especially which Xcode broke.
       fail-fast: false
       matrix:
@@ -90,11 +90,11 @@ jobs:
           mit_count=$(find Sources/NookSurface -name '*.swift' | wc -l | tr -d ' ')
           apache_count=$(find Sources Tests Examples App -name '*.swift' -not -path 'Sources/NookSurface/*' | wc -l | tr -d ' ')
           if [ "$mit_count" -lt 1 ]; then
-            echo "::error::no .swift files under Sources/NookSurface — did the MIT module move? License check would pass vacuously."
+            echo "::error::no .swift files under Sources/NookSurface - did the MIT module move? License check would pass vacuously."
             fail=1
           fi
           if [ "$apache_count" -lt 1 ]; then
-            echo "::error::no Apache-2.0 .swift files found — did the source layout move? License check would pass vacuously."
+            echo "::error::no Apache-2.0 .swift files found - did the source layout move? License check would pass vacuously."
             fail=1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ DerivedData/
 *.xcuserstate
 xcuserdata/
 
-# The Xcode project is generated from project.yml by xcodegen — committing it
+# The Xcode project is generated from project.yml by xcodegen - committing it
 # produces noisy merge conflicts on every regenerate. project.yml is the
 # source of truth; run Scripts/regenerate-xcodeproj.sh after a fresh clone or
 # after editing project.yml.
@@ -15,5 +15,5 @@ Nook.xcodeproj/
 # built by Swift Package Index from .spi.yml, so this never needs committing.
 .docs-out/
 
-# Internal planning notes — not part of the published framework.
+# Internal planning notes - not part of the published framework.
 .notes/

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import Foundation
 import PackageDescription
 
-/// Centralized strict-concurrency checking — applied to every target so the
+/// Centralized strict-concurrency checking - applied to every target so the
 /// examples (which a host developer reads as authoritative idiom) and tests
 /// (which a regression must not silently bypass) can't drift from the
 /// concurrency rules the library targets enforce.
@@ -22,14 +22,14 @@ var package = Package(
         .executable(name: "Nook", targets: ["NookExecutable"]),
         // Library product so the Xcode app target can `import NookApp` and
         // call `NookApp.main()` from `App/main.swift`. Same module the SPM
-        // trampoline links against — behavior cannot drift between the two
+        // trampoline links against - behavior cannot drift between the two
         // launch surfaces.
         .library(name: "NookApp", targets: ["NookApp"]),
-        // Optional Tier 3 add-on components (file shelf, …). A consumer adds this
+        // Optional Tier 3 add-on components (file shelf, ...). A consumer adds this
         // product to their target's dependencies only when they want it; it is not
         // pulled in by `NookApp`.
         .library(name: "NookComponents", targets: ["NookComponents"]),
-        // Example apps under `Examples/` — each a single `main.swift` showing one
+        // Example apps under `Examples/` - each a single `main.swift` showing one
         // way to build on OpenNook through public API only. Run with `swift run
         // HelloNook` (or `ClockNook` / `ThemedNook` / `ChromeNook` / `LayoutNook` /
         // `ShelfNook` / `ActivityNook` / `VolumeNook` / `MultiNook`).
@@ -50,7 +50,7 @@ var package = Package(
             // Strict-concurrency checking is opted in via an upcoming feature so the
             // `@MainActor`/`Sendable` correctness is compiler-enforced. Kept as an
             // upcoming feature (not a tools-version bump to 6.0) so this stays a
-            // non-breaking change for consumers — deliberate architecture decision.
+            // non-breaking change for consumers - deliberate architecture decision.
             swiftSettings: strictConcurrency
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ swift test          # run the test suite
 ```
 
 Once it's running, press **⌥⌘;** (or use the menu-bar item) to expand the
-nook. You can rebind that shortcut in Settings → Shortcut & nook.
+nook. You can rebind that shortcut in Settings -> Shortcut & nook.
 
 For a real `.app` bundle (signing, notarization, Cmd-R in Xcode):
 
@@ -203,7 +203,7 @@ dependency container threaded into views.
 `toggleNook()`, `toggleKeepNookOpen()` are the lifecycle vocabulary; the global
 hotkey and menu-bar fallback already call into them.
 
-Rename the product (`Nook` → your app) by editing `project.yml`,
+Rename the product (`Nook` -> your app) by editing `project.yml`,
 `App/Info.plist`, and the `Package.swift` product name when you're ready to
 ship.
 
@@ -233,7 +233,7 @@ and runs on earlier systems. See
 [Surface materials](https://opennook.dev/guides/surface-materials/).
 
 **Chrome behavior.** Hover side-effects, the cold-launch shimmer, and the
-appearance→backdrop mapping:
+appearance->backdrop mapping:
 
 ```swift
 configuration.chromeBehavior = NookChromeBehavior(

--- a/Sources/NookComponents/Activities/NookActivityQueue.swift
+++ b/Sources/NookComponents/Activities/NookActivityQueue.swift
@@ -65,6 +65,8 @@ public final class NookActivityQueue: ObservableObject {
     /// Connects the queue to the surface it presents through, and starts draining any
     /// already-queued activities. Call once — `NookConfiguration.onReady` is the seam.
     ///
+    /// - Parameter presenter: the surface the queue drives its takeovers through - the
+    ///   host `AppCoordinator` in a single-module app, or the active module's coordinator.
     /// - Parameter moduleID: the module this queue belongs to, stamped onto its surface
     ///   claims. When `nil`, the foreground module at bind time is assumed — correct for
     ///   a single-module host. A multi-module host should pass `context.descriptor.id`

--- a/Sources/NookKit/App/AppCoordinator.swift
+++ b/Sources/NookKit/App/AppCoordinator.swift
@@ -843,7 +843,7 @@ public final class AppCoordinator: ObservableObject {
     }
 
     /// Shows the Settings screen. When the host disabled Settings
-    /// (``NookConfiguration/showsSettings`` is `false`) there is no Settings UI, so this
+    /// (``NookTopBarConfiguration/showsSettings`` is `false`) there is no Settings UI, so this
     /// falls back to showing the home surface and `viewMode` stays `.home`.
     public func showSettings() {
         guard configuration.topBar.showsSettings else {

--- a/Sources/NookKit/System/HotkeyController.swift
+++ b/Sources/NookKit/System/HotkeyController.swift
@@ -20,7 +20,7 @@ import Foundation
 /// Carbon delivers `kEventHotKeyPressed` callbacks on the main thread in practice, but
 /// that is not contractually guaranteed, so the C event handler does not touch any
 /// controller state directly — it hops the lookup-and-dispatch onto the main actor via
-/// ``dispatchHandler(forCarbonID:)``. That makes the single-actor invariant provable
+/// `dispatchHandler(forCarbonID:)`. That makes the single-actor invariant provable
 /// rather than accidental.
 @MainActor
 public final class HotkeyController {

--- a/Sources/NookKit/System/NookHotkey.swift
+++ b/Sources/NookKit/System/NookHotkey.swift
@@ -9,7 +9,7 @@ import AppKit
 import Carbon
 
 /// A user-configurable global hotkey. Stores the Carbon virtual key code and modifier
-/// mask needed by ``HotkeyController/register(keyCode:modifiers:handler:)``, plus a
+/// mask needed by ``HotkeyController/register(_:keyCode:modifiers:handler:)``, plus a
 /// display symbol for the non-modifier key (the modifier glyphs are derived).
 public struct NookHotkey: Equatable, Codable, Sendable {
     /// Carbon `kVK_*` virtual key code. Matches `NSEvent.keyCode`.


### PR DESCRIPTION
Two cleanups flagged in the docs follow-up.

DocC doc-comment fixes (the genuinely-stale references the DocC build surfaced):
- NookHotkey: HotkeyController/register(keyCode:modifiers:handler:) -> register(_:keyCode:modifiers:handler:) (the real signature has a leading unnamed parameter).
- HotkeyController: de-link dispatchHandler(forCarbonID:) - it is private, so a public doc comment cannot symbol-link it.
- AppCoordinator: NookConfiguration/showsSettings -> NookTopBarConfiguration/showsSettings (the flag lives on topBar).
- NookActivityQueue.bind: document the previously-undocumented 'presenter' parameter.
All four warnings confirmed cleared (57 -> 54). The remaining warnings are cross-module / external-framework / private-symbol link limitations, not bugs, so --warnings-as-errors is not pursued (it would mean de-linking legitimate references).

ASCII typography:
- README, Package.swift, ci.yml, .gitignore: em-dashes -> ' - ', ellipsis -> '...', the arrows -> '->' / '<->'. Legitimate Unicode is preserved (the Mac key glyphs, the Prefe'rences localization example, the middot separator).

Note: non-ASCII typography is pervasive across the rest of the codebase's comments; a full repo-wide sweep is a separate, larger change (see PR discussion / summary).