### PR TITLE
Normalize ASCII typography in comments and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
           fi
           echo "License headers OK."
 
+  ascii:
+    name: ASCII typography (comments & docs)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check banned typography in comments and markdown prose
+        run: ./Scripts/check-ascii.sh
+
   docs:
     name: DocC build
     runs-on: macos-15

--- a/App/main.swift
+++ b/App/main.swift
@@ -8,7 +8,7 @@
 // Xcode app-target trampoline. Cmd-R / xcodebuild assembles a real `.app`
 // bundle around this binary with `App/Info.plist`. Behaviour is identical
 // to the SPM executable trampoline at `Sources/NookExecutable/main.swift`
-// — both delegate to the shared library entry point in `NookApp`.
+// - both delegate to the shared library entry point in `NookApp`.
 
 import NookApp
 

--- a/Examples/ActivityNook/main.swift
+++ b/Examples/ActivityNook/main.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// ActivityNook — the live-activity queue from the NookComponents add-on.
+// ActivityNook - the live-activity queue from the NookComponents add-on.
 //
 // A NookActivityQueue collects transient activities and presents them one at a time,
 // briefly taking over the expanded surface for each. This demo enqueues a sample
@@ -21,7 +21,7 @@ import NookApp
 import NookComponents
 import SwiftUI
 
-/// Shown when the queue is idle — the host's normal home content.
+/// Shown when the queue is idle - the host's normal home content.
 struct ActivityNookHome: View {
     @Environment(\.nookResolvedTheme) private var theme
 
@@ -43,7 +43,7 @@ struct ActivityNookHome: View {
 }
 
 /// A module that owns a `NookActivityQueue`. Because the queue is a transient surface
-/// presenter, the module must `quiesce()` it before being switched away — that is the
+/// presenter, the module must `quiesce()` it before being switched away - that is the
 /// purpose of `prepareForSwitchAway()`.
 @MainActor
 final class ActivityModule: NookModule {

--- a/Examples/ChromeNook/main.swift
+++ b/Examples/ChromeNook/main.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// ChromeNook — a tour of OpenNook's deeper chrome-customization seams.
+// ChromeNook - a tour of OpenNook's deeper chrome-customization seams.
 //
 // Where ThemedNook covers a host theme + lifecycle hooks, this shows the rest of
 // the `NookConfiguration` surface, all additive and non-breaking:
@@ -60,7 +60,7 @@ struct ChromeHomeView: View {
     }
 }
 
-/// A top-bar trailing action — rendered left of the framework lock + gear. It reads the
+/// A top-bar trailing action - rendered left of the framework lock + gear. It reads the
 /// resolved theme and observes `AppState`, like the rest of the chrome.
 struct ChromeTrailingActions: View {
     @EnvironmentObject private var appState: AppState
@@ -84,7 +84,7 @@ var configuration = NookConfiguration()
 configuration.setHome { ChromeHomeView() }
 configuration.setTopBarTrailingItems { ChromeTrailingActions() }
 
-// Launch defaults — ship translucent chrome out of the box (seed-only: a user's
+// Launch defaults - ship translucent chrome out of the box (seed-only: a user's
 // Settings change still wins, and the seed is never persisted).
 configuration.preferenceDefaults = NookPreferenceDefaults(
     appearance: NookAppearancePreferences(
@@ -94,15 +94,15 @@ configuration.preferenceDefaults = NookPreferenceDefaults(
     )
 )
 
-// Chrome behavior — opt into hover side-effects (keep-visible + haptics).
+// Chrome behavior - opt into hover side-effects (keep-visible + haptics).
 configuration.chromeBehavior = NookChromeBehavior(hoverBehavior: .all)
 
-// Labels / metrics / motion — localize a string, widen the breadcrumb, snappier swap.
+// Labels / metrics / motion - localize a string, widen the breadcrumb, snappier swap.
 configuration.labels.settingsBreadcrumb = "Preferences"
 configuration.metrics.breadcrumbMaxWidth = 160
 configuration.motion.viewModeChange = .snappy
 
-// Identity — name, tagline, and a custom brand mark replacing the OpenNook glyph.
+// Identity - name, tagline, and a custom brand mark replacing the OpenNook glyph.
 configuration.branding = NookHostBranding(
     hostName: "ChromeNook",
     hostTagline: "A tour of OpenNook's chrome-customization seams.",

--- a/Examples/ClockNook/main.swift
+++ b/Examples/ClockNook/main.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// ClockNook — a home surface plus a custom compact slot.
+// ClockNook - a home surface plus a custom compact slot.
 //
 // Shows two registration knobs: `setHome` for the expanded surface and
 // `setCompactTrailing` for the glyph flanking the notch when collapsed.

--- a/Examples/HelloNook/main.swift
+++ b/Examples/HelloNook/main.swift
@@ -5,10 +5,10 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// HelloNook — the smallest possible OpenNook app.
+// HelloNook - the smallest possible OpenNook app.
 //
 // "Register a view, go": hand `NookApp.main` one SwiftUI view and you have a notch
-// app — top bar, Settings, hotkey, compact pill all come for free. Run with
+// app - top bar, Settings, hotkey, compact pill all come for free. Run with
 // `swift run HelloNook`, then press ⌥⌘; to expand.
 
 import NookApp

--- a/Examples/LayoutNook/main.swift
+++ b/Examples/LayoutNook/main.swift
@@ -5,11 +5,11 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// LayoutNook — recommended expanded-width and content-inset patterns for host apps.
+// LayoutNook - recommended expanded-width and content-inset patterns for host apps.
 //
 // Where ChromeNook tours chrome-customization seams and ThemedNook shows palette +
 // lifecycle hooks, this example focuses on how the expanded panel's width and insets
-// compose — and how a home view should read `\.nookContentInsets` instead of adding
+// compose - and how a home view should read `\.nookContentInsets` instead of adding
 // its own horizontal padding.
 //
 // Run with `swift run LayoutNook`, then press ⌥⌘; to expand.
@@ -20,7 +20,7 @@ import NookApp
 import SwiftUI
 
 /// Recommended home layout: edge-aligned content and a full-width bottom command row
-/// both read `\.nookContentInsets` — no extra `.padding(.horizontal, …)` on the root.
+/// both read `\.nookContentInsets` - no extra `.padding(.horizontal, ...)` on the root.
 struct LayoutHomeView: View {
     @Environment(\.nookContentInsets) private var contentInsets
     @Environment(\.nookResolvedTheme) private var theme
@@ -85,7 +85,7 @@ configuration.setHome { LayoutHomeView() }
 // this only fixes the inner content column so home and Settings don't resize each other.
 configuration.expandedWidth = 600
 
-// Trim the chrome's bottom safe-area strip (default 8 → 2) so centered rows sit closer
+// Trim the chrome's bottom safe-area strip (default 8 -> 2) so centered rows sit closer
 // to the rounded bottom. Edge-aligned rows still clear the curve via `nookContentInsets`.
 configuration.style = NookStyle(
     topCornerRadius: 19,
@@ -94,7 +94,7 @@ configuration.style = NookStyle(
 )
 
 // `metrics.edgePadding` (default 8) is already applied by `NookExpandedView`. Do not
-// mirror it with `.padding(.horizontal, 12)` on the home root — that stacks insets and
+// mirror it with `.padding(.horizontal, 12)` on the home root - that stacks insets and
 // leaves dead space beside answer text and bottom command rows.
 
 NookApp.main(configuration)

--- a/Examples/MultiNook/main.swift
+++ b/Examples/MultiNook/main.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// MultiNook — one host process, several interchangeable notch apps.
+// MultiNook - one host process, several interchangeable notch apps.
 //
 // A NookHostConfiguration registers a set of modules; the host shows one at a time and
 // the user switches between them through the switcher strip at the top of the expanded
@@ -39,7 +39,7 @@ struct ModuleHome: View {
     }
 }
 
-/// A trivial service whose only job is to be resolved through `AppServices` — the
+/// A trivial service whose only job is to be resolved through `AppServices` - the
 /// counter module's persistence, lifted behind a type so its views need not know how
 /// the count is stored. Not actor-isolated: a `ServiceKey`'s `defaultValue` is
 /// nonisolated (the SwiftUI `EnvironmentKey` pattern), so its backing type must be too.
@@ -62,12 +62,12 @@ final class LaunchTracker: Sendable {
 }
 
 /// The `ServiceKey` the counter module registers its `LaunchTracker` against. Resolving
-/// `LaunchTrackerKey.self` is total — it falls back to `defaultValue` if unregistered.
+/// `LaunchTrackerKey.self` is total - it falls back to `defaultValue` if unregistered.
 struct LaunchTrackerKey: ServiceKey {
     static let defaultValue: LaunchTracker = .unregistered
 }
 
-/// A module that carries its own product state — a launch counter persisted in the
+/// A module that carries its own product state - a launch counter persisted in the
 /// module's isolated `UserDefaults` suite, exposed to its views through the type-safe
 /// `AppServices` container keyed by `LaunchTrackerKey`. Shows the full `NookModule`
 /// protocol; the simpler modules below register a `NookConfiguration` closure directly.
@@ -104,7 +104,7 @@ final class CounterModule: NookModule {
 }
 
 /// The counter module's home view. It resolves the launch count out of the module's
-/// `AppServices` bag — never optional, thanks to `LaunchTrackerKey.defaultValue`.
+/// `AppServices` bag - never optional, thanks to `LaunchTrackerKey.defaultValue`.
 struct CounterHome: View {
     @Environment(\.appServices) private var services
 

--- a/Examples/ShelfNook/main.swift
+++ b/Examples/ShelfNook/main.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// ShelfNook — a file shelf in the notch, from the NookComponents add-on.
+// ShelfNook - a file shelf in the notch, from the NookComponents add-on.
 //
 // Drag files onto the notch and they collect in the shelf; drag them back out to
 // Finder or another app. The shelf persists across launches. Run with
@@ -15,7 +15,7 @@ import NookApp
 import NookComponents
 import SwiftUI
 
-// `NookApp.main { … }` builds the configuration on the main actor, so the
+// `NookApp.main { ... }` builds the configuration on the main actor, so the
 // main-actor-isolated ShelfStore can be constructed here.
 NookApp.main {
     // One shelf model, shared between the home view that renders it and the drop
@@ -25,19 +25,19 @@ NookApp.main {
     var configuration = NookConfiguration()
     configuration.setHome { ShelfHome(store: shelf) }
     // `NookConfiguration.onFileDrop` is typed `@Sendable @MainActor ([URL]) -> Bool`
-    // — the closure runs on the main actor, so it can call `ShelfStore.accept`
+    // - the closure runs on the main actor, so it can call `ShelfStore.accept`
     // directly without any `assumeIsolated` hop.
     configuration.onFileDrop = { urls in shelf.accept(urls) }
     return configuration
 }
 
 /// The shelf, with click-to-import folded into its drop zone via the host's
-/// ``NookFilePicker`` — the picker-driven counterpart to drag-and-drop, in one surface.
+/// ``NookFilePicker`` - the picker-driven counterpart to drag-and-drop, in one surface.
 ///
 /// Picker caveat: `swift run` produces an unbundled, unsandboxed binary with no
 /// powerbox, so the open panel cannot enter TCC-protected folders (Downloads, etc.).
 /// Build and run the signed `Nook.app` (the `NookHostApp` Xcode target) to exercise the
-/// picker for real — see the Shipping checklist in README.md.
+/// picker for real - see the Shipping checklist in README.md.
 private struct ShelfHome: View {
     let store: ShelfStore
     @Environment(\.appServices) private var services

--- a/Examples/ThemedNook/main.swift
+++ b/Examples/ThemedNook/main.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// ThemedNook — a host-supplied theme plus lifecycle hooks.
+// ThemedNook - a host-supplied theme plus lifecycle hooks.
 //
 // Shows `NookConfiguration.theme` (a custom `NookResolvedTheme` paints the chrome
 // labels) and the `onExpand` / `onCompact` callbacks. Run with `swift run ThemedNook`
@@ -15,7 +15,7 @@ import NookApp
 import SwiftUI
 
 /// A host-built palette. `NookResolvedTheme`'s public initializer accepts any colors;
-/// the framework recommends explicit values (not system-adaptive ones) — see the
+/// the framework recommends explicit values (not system-adaptive ones) - see the
 /// `NookResolvedTheme` type docs for why.
 enum SunsetTheme {
     @MainActor

--- a/Examples/VolumeNook/main.swift
+++ b/Examples/VolumeNook/main.swift
@@ -5,11 +5,11 @@
 // you may not use this file except in compliance with the License.
 // A copy is included at /LICENSE in the repository root.
 
-// VolumeNook — an ambient volume glyph in the compact pill (NookComponents).
+// VolumeNook - an ambient volume glyph in the compact pill (NookComponents).
 //
 // SystemVolumeObserver tracks the default output device via public CoreAudio APIs;
 // NookVolumeIndicator renders the level as a compact-slot glyph. Run with
-// `swift run VolumeNook`, leave the nook collapsed, and change the volume — the glyph
+// `swift run VolumeNook`, leave the nook collapsed, and change the volume - the glyph
 // to the right of the notch updates. It shows the level; it does not replace Apple's
 // volume HUD.
 
@@ -17,7 +17,7 @@ import NookApp
 import NookComponents
 import SwiftUI
 
-// `NookApp.main { … }` builds the configuration on the main actor, so the
+// `NookApp.main { ... }` builds the configuration on the main actor, so the
 // main-actor-isolated SystemVolumeObserver can be constructed here.
 NookApp.main {
     // One observer, rendered in the compact-trailing slot.

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -20,7 +20,7 @@ the iteration:
 
 | Path  | Command                                                              | When                                                          | Limitations                                                              |
 | ----- | -------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| SPM   | `swift run Nook` (or `Scripts/dev-run.sh`)                    | Fast headless iteration                                       | No `Info.plist` on disk → Launch Services can't route URL-scheme links   |
+| SPM   | `swift run Nook` (or `Scripts/dev-run.sh`)                    | Fast headless iteration                                       | No `Info.plist` on disk -> Launch Services can't route URL-scheme links   |
 | Xcode | Cmd-R in `Nook.xcodeproj` or `xcodebuild -scheme NookHostApp build` | End-to-end (signing, notarization, bundled `.app`)        | Slower first build; `DerivedData/` lives in `.build/xcode/`              |
 
 `swift test` runs the test suite from the package root. Both paths share the

--- a/Scripts/apply-license-headers.sh
+++ b/Scripts/apply-license-headers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Apply SPDX license headers to source files. Idempotent — skips files that already carry
+# Apply SPDX license headers to source files. Idempotent - skips files that already carry
 # an `SPDX-License-Identifier` line. Run from the repo root.
 set -euo pipefail
 

--- a/Scripts/check-ascii.sh
+++ b/Scripts/check-ascii.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Fail if banned typography appears in comments or markdown prose.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec python3 "$ROOT/Scripts/normalize-ascii-typography.py" --check

--- a/Scripts/normalize-ascii-typography.py
+++ b/Scripts/normalize-ascii-typography.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Normalize banned typography to ASCII in comments and markdown prose only."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BANNED = {
+    "\u2013": "-",
+    "\u2026": "...",
+    "\u2018": "'",
+    "\u2019": "'",
+    "\u201c": '"',
+    "\u201d": '"',
+    "\u2192": "->",
+    "\u2194": "<->",
+}
+
+SPDX_RE = re.compile(r"^\s*//\s*SPDX-License-Identifier:")
+
+
+def normalize_em_dash(text: str) -> str:
+    return re.sub(r"\s*\u2014\s*", " - ", text)
+
+
+def convert_banned(text: str) -> str:
+    out = normalize_em_dash(text)
+    for src, dst in BANNED.items():
+        out = out.replace(src, dst)
+    return out
+
+
+def is_spdx_line(line: str) -> bool:
+    return bool(SPDX_RE.match(line))
+
+
+def transform_swift(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(text)
+
+    while i < n:
+        # Line comment
+        if text.startswith("//", i):
+            line_end = text.find("\n", i)
+            if line_end == -1:
+                line_end = n
+            line = text[i:line_end]
+            out.append(line if is_spdx_line(line) else convert_banned(line))
+            i = line_end
+            continue
+
+        # Block comment
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            if end == -1:
+                out.append(convert_banned(text[i:]))
+                break
+            out.append(convert_banned(text[i : end + 2]))
+            i = end + 2
+            continue
+
+        # Multiline string
+        if text.startswith('"""', i):
+            end = text.find('"""', i + 3)
+            if end == -1:
+                out.append(text[i:])
+                break
+            out.append(text[i : end + 3])
+            i = end + 3
+            continue
+
+        # Single-line string
+        if text[i] == '"':
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            out.append(text[i:j])
+            i = j
+            continue
+
+        # Regular code: copy until next token boundary.
+        j = i + 1
+        while j < n:
+            if text[j] in '"':
+                break
+            if text.startswith("//", j) or text.startswith("/*", j) or text.startswith('"""', j):
+                break
+            j += 1
+        out.append(text[i:j])
+        i = j
+
+    return "".join(out)
+
+
+def transform_markdown(text: str) -> str:
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_fence = False
+    fence_marker = ""
+
+    while i < n:
+        line_end = text.find("\n", i)
+        if line_end == -1:
+            line_end = n
+        line = text[i:line_end]
+        newline = text[line_end : line_end + 1] if line_end < n else ""
+
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            marker = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif stripped.startswith(fence_marker):
+                in_fence = False
+                fence_marker = ""
+            out.append(line + newline)
+            i = line_end + len(newline)
+            continue
+
+        if in_fence:
+            out.append(line + newline)
+        else:
+            out.append(transform_markdown_line(line) + newline)
+        i = line_end + len(newline)
+
+    return "".join(out)
+
+
+def transform_markdown_line(line: str) -> str:
+    parts: list[str] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if line[i] == "`":
+            j = line.find("`", i + 1)
+            if j == -1:
+                parts.append(convert_banned(line[i:]))
+                break
+            parts.append(line[i : j + 1])
+            i = j + 1
+            continue
+        j = i
+        while j < n and line[j] != "`":
+            j += 1
+        parts.append(convert_banned(line[i:j]))
+        i = j
+    return "".join(parts)
+
+
+def transform_shell_or_yaml(text: str) -> str:
+    out_lines: list[str] = []
+    for line in text.splitlines(keepends=True):
+        body = line.rstrip("\n\r")
+        ending = line[len(body) :]
+        hash_idx = body.find("#")
+        if hash_idx == -1:
+            out_lines.append(line)
+            continue
+        before = body[:hash_idx]
+        comment = body[hash_idx:]
+        out_lines.append(before + convert_banned(comment) + ending)
+    return "".join(out_lines)
+
+
+def transform_file(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+
+    if suffix == ".swift":
+        new = transform_swift(text)
+    elif suffix in {".md", ".mdx"}:
+        new = transform_markdown(text)
+    elif suffix == ".plist":
+        return None
+    elif suffix in {".sh", ".yml", ".yaml"} or path.name == ".gitignore":
+        new = transform_shell_or_yaml(text)
+    else:
+        return None
+
+    return new if new != text else None
+
+
+def tracked_text_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    skip_suffix = {
+        ".png", ".jpg", ".jpeg", ".ico", ".svg",
+        ".woff", ".woff2", ".otf", ".ttf", ".plist",
+    }
+    files: list[Path] = []
+    for rel in result.stdout.splitlines():
+        p = REPO_ROOT / rel
+        if p.suffix.lower() in skip_suffix or not p.is_file():
+            continue
+        try:
+            p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        files.append(p)
+    return files
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    check = "--check" in sys.argv
+    changed = 0
+    violations: list[str] = []
+    for path in tracked_text_files():
+        new_text = transform_file(path)
+        if new_text is None:
+            continue
+        changed += 1
+        rel = path.relative_to(REPO_ROOT)
+        if check:
+            violations.append(str(rel))
+        elif dry_run:
+            print(rel)
+        else:
+            path.write_text(new_text, encoding="utf-8")
+            print(rel)
+    if check:
+        if violations:
+            print("Banned typography found in comments/markdown prose:", file=sys.stderr)
+            for v in violations:
+                print(f"  {v}", file=sys.stderr)
+            return 1
+        print("ASCII typography check passed.", file=sys.stderr)
+        return 0
+    action = "Would change" if dry_run else "Changed"
+    print(f"{action} {changed} file(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/regenerate-xcodeproj.sh
+++ b/Scripts/regenerate-xcodeproj.sh
@@ -2,7 +2,7 @@
 # regenerate-xcodeproj.sh
 # Rebuilds Nook.xcodeproj from project.yml (the source of truth).
 #
-# The .xcodeproj is gitignored — it's a generated artifact. Run this script
+# The .xcodeproj is gitignored - it's a generated artifact. Run this script
 # after editing project.yml, or after a fresh clone before opening the
 # project in Xcode for the first time.
 #

--- a/Sources/NookApp/NookApp.swift
+++ b/Sources/NookApp/NookApp.swift
@@ -10,7 +10,7 @@ import Combine
 import SwiftUI
 
 // Re-exported so a host app needs only `import NookApp` to reach the registration API
-// (`NookConfiguration`, `NookResolvedTheme`, `AppState`, …) and the surface types.
+// (`NookConfiguration`, `NookResolvedTheme`, `AppState`, ...) and the surface types.
 @_exported import NookKit
 @_exported import NookSurface
 
@@ -56,7 +56,7 @@ public enum NookApp {
         main(host)
     }
 
-    /// "Register a view, go" — boots a notch app whose expanded home surface is the
+    /// "Register a view, go" - boots a notch app whose expanded home surface is the
     /// supplied view. Everything else (top bar, Settings, compact glyphs, theme) keeps
     /// the framework defaults.
     ///
@@ -73,8 +73,8 @@ public enum NookApp {
 
     /// Boots a notch app, building the ``NookConfiguration`` on the main actor.
     ///
-    /// Use this overload when setup constructs main-actor-isolated types — a
-    /// `NookComponents` `ShelfStore` or `NookActivityQueue`, a host view model — which
+    /// Use this overload when setup constructs main-actor-isolated types - a
+    /// `NookComponents` `ShelfStore` or `NookActivityQueue`, a host view model - which
     /// can't be created from the (non-isolated) top level of a `main.swift`:
     ///
     /// ```swift
@@ -105,7 +105,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
         self.moduleHost = moduleHost
         // Seed the process-global preferences from the host's launch defaults before the
         // coordinator starts, so the first paint and the initial hotkey registration use
-        // them (an `onReady` hook would run too late — after both).
+        // them (an `onReady` hook would run too late - after both).
         self.coordinator = AppCoordinator(
             appState: AppState(preferenceDefaults: host.preferenceDefaults),
             moduleHost: moduleHost
@@ -135,8 +135,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
         statusItem = item
         rebuildMenu()
 
-        // The "Settings…" item tracks the active module's `showsSettings`, which can
-        // differ across modules — so rebuild the menu whenever the active module changes
+        // The "Settings..." item tracks the active module's `showsSettings`, which can
+        // differ across modules - so rebuild the menu whenever the active module changes
         // instead of freezing the launch module's chrome into the menu bar.
         moduleHost.$activeModuleID
             .dropFirst()
@@ -155,9 +155,9 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
             action: #selector(showNook),
             keyEquivalent: ";"
         ))
-        // "Settings…" tracks the chrome: dropped when the active module disabled Settings,
+        // "Settings..." tracks the chrome: dropped when the active module disabled Settings,
         // since there is no Settings UI to open. "Toggle Stay Expanded" is kept regardless
-        // — it's chrome-independent and is the only keep-open control left once the top
+        // - it's chrome-independent and is the only keep-open control left once the top
         // bar (and its lock) is hidden.
         if moduleHost.configuration.topBar.showsSettings {
             menu.addItem(NSMenuItem(
@@ -172,7 +172,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: "k"
         ))
 
-        // Modules — a multi-module host that left switching in the menu bar (the default
+        // Modules - a multi-module host that left switching in the menu bar (the default
         // placement) gets a section here: one item per module, a check on the active one,
         // selecting switches. This keeps switching off the host's expanded surface.
         if moduleHost.switcherPlacement.listsModulesInMenuBar && moduleHost.isMultiModule {

--- a/Sources/NookComponents/Activities/NookActivity.swift
+++ b/Sources/NookComponents/Activities/NookActivity.swift
@@ -17,7 +17,7 @@ public enum NookActivityPriority: Int, Comparable, Sendable {
     }
 }
 
-/// One transient activity to surface in the notch — a "download finished", a "build
+/// One transient activity to surface in the notch - a "download finished", a "build
 /// succeeded", a "message arrived".
 ///
 /// Hand activities to a ``NookActivityQueue``; it orders them by ``priority``, collapses

--- a/Sources/NookComponents/Activities/NookActivityHost.swift
+++ b/Sources/NookComponents/Activities/NookActivityHost.swift
@@ -40,7 +40,7 @@ public struct NookActivityHost<Content: View>: View {
     }
 }
 
-/// The default activity card — icon, title, subtitle. Reads `\.nookResolvedTheme` from
+/// The default activity card - icon, title, subtitle. Reads `\.nookResolvedTheme` from
 /// the environment so it tracks the configured chrome palette.
 public struct NookActivityCard: View {
     private let activity: NookActivity

--- a/Sources/NookComponents/Activities/NookActivityQueue.swift
+++ b/Sources/NookComponents/Activities/NookActivityQueue.swift
@@ -14,19 +14,19 @@ import NookKit
 /// Enqueue ``NookActivity`` values; the queue drains them one at a time, highest
 /// ``NookActivityPriority/high`` first, collapsing any that share a `coalescingKey`.
 /// Presenting an activity briefly takes over the expanded surface through a
-/// ``NookSurfacePresenting`` — typically `AppCoordinator`, supplied via
+/// ``NookSurfacePresenting`` - typically `AppCoordinator`, supplied via
 /// `NookConfiguration.onReady`:
 ///
 /// ```swift
 /// let queue = NookActivityQueue()
 /// configuration.onReady = { queue.bind(to: $0) }
-/// // …later, from anywhere on the main actor:
+/// // ...later, from anywhere on the main actor:
 /// queue.enqueue(NookActivity(title: "Build finished", systemImage: "hammer"))
 /// ```
 ///
 /// The queue **yields to the user**: while the user is hovering or has opened the nook
 /// themselves it pauses, resuming once they disengage. It does not preempt an activity
-/// that is already on screen — priority orders only what is still pending.
+/// that is already on screen - priority orders only what is still pending.
 @MainActor
 public final class NookActivityQueue: ObservableObject {
     /// The activity currently on screen, or `nil`. A host view (see ``NookActivityHost``)
@@ -41,7 +41,7 @@ public final class NookActivityQueue: ObservableObject {
 
     private weak var presenter: (any NookSurfacePresenting)?
 
-    /// The module this queue presents on behalf of — stamped onto every surface claim so
+    /// The module this queue presents on behalf of - stamped onto every surface claim so
     /// the arbiter can gate a background module's activities. Captured at ``bind(to:moduleID:)``.
     private var moduleID = ""
 
@@ -53,7 +53,7 @@ public final class NookActivityQueue: ObservableObject {
     /// ``quiesce()`` uses this to release a held claim when stopping mid-presentation.
     private var activeToken: NookSurfaceToken?
 
-    /// Injectable sleep — real time in production, instant in tests.
+    /// Injectable sleep - real time in production, instant in tests.
     private let sleep: @Sendable (Duration) async -> Void
 
     /// - Parameter sleep: how the queue waits out an activity's `dwell`. Defaults to a
@@ -63,12 +63,12 @@ public final class NookActivityQueue: ObservableObject {
     }
 
     /// Connects the queue to the surface it presents through, and starts draining any
-    /// already-queued activities. Call once — `NookConfiguration.onReady` is the seam.
+    /// already-queued activities. Call once - `NookConfiguration.onReady` is the seam.
     ///
     /// - Parameter presenter: the surface the queue drives its takeovers through - the
     ///   host `AppCoordinator` in a single-module app, or the active module's coordinator.
     /// - Parameter moduleID: the module this queue belongs to, stamped onto its surface
-    ///   claims. When `nil`, the foreground module at bind time is assumed — correct for
+    ///   claims. When `nil`, the foreground module at bind time is assumed - correct for
     ///   a single-module host. A multi-module host should pass `context.descriptor.id`
     ///   so a backgrounded module's activities are gated correctly.
     public func bind(to presenter: any NookSurfacePresenting, moduleID: String? = nil) {
@@ -104,11 +104,11 @@ public final class NookActivityQueue: ObservableObject {
     /// Cooperative on purpose: a hard cancel mid-dwell would skip the
     /// `endTransientPresentation` call in the drain loop and strand the arbiter claim
     /// until the next ``quiesce()`` released it. Use ``quiesce()`` when you need hard
-    /// teardown — e.g. on module switch-away or queue destruction.
+    /// teardown - e.g. on module switch-away or queue destruction.
     public func suspend() {
         guard !isSuspended else { return }
         isSuspended = true
-        // Do NOT cancel `drainTask` here — see doc comment. The loop checks
+        // Do NOT cancel `drainTask` here - see doc comment. The loop checks
         // `isSuspended` at the top of each iteration and at the engagement-wait poll;
         // it exits on its own once the current activity finishes (or immediately if
         // it was parked in a wait).
@@ -123,7 +123,7 @@ public final class NookActivityQueue: ObservableObject {
 
     /// Stops all draining, joins the drain task, and releases any held surface token.
     ///
-    /// Unlike ``suspend()`` — which detaches the drain task and returns immediately —
+    /// Unlike ``suspend()`` - which detaches the drain task and returns immediately - 
     /// `quiesce()` *awaits* the drain task to fully unwind, then hands back any
     /// in-flight surface claim. After it returns the queue is provably no longer
     /// touching the surface, so the owning module is safe to switch away or unload.
@@ -152,7 +152,7 @@ public final class NookActivityQueue: ObservableObject {
         drainTask = Task { [weak self] in
             await self?.drain()
             // Only a drain that finished *naturally* clears the handle. A cancelled
-            // drain was detached by `suspend()`, which already niled the handle — and
+            // drain was detached by `suspend()`, which already niled the handle - and
             // a `resume()` may since have installed a fresh drain; don't clobber it.
             if !Task.isCancelled {
                 self?.drainTask = nil
@@ -172,7 +172,7 @@ public final class NookActivityQueue: ObservableObject {
 
             let claim = NookSurfaceClaim(moduleID: moduleID, priority: activity.priority.surfacePriority)
             guard let token = await presenter.beginTransientPresentation(claim) else {
-                // Denied — the user grabbed the surface, or another presenter outranks
+                // Denied - the user grabbed the surface, or another presenter outranks
                 // this claim. Put the activity back at the front and back off briefly so
                 // a contended surface is retried without spinning.
                 requeue(activity)
@@ -187,15 +187,15 @@ public final class NookActivityQueue: ObservableObject {
             current = activity
             await sleep(activity.dwell)
             // Keep `current` set across the `endTransientPresentation` await, then clear
-            // it — this holds the activity card on screen while the surface hands the
+            // it - this holds the activity card on screen while the surface hands the
             // claim back.
             //
             // Honest caveat: `endTransientPresentation` returns when the claim is
             // released, not necessarily when a follow-on collapse *animation* has
             // finished. If the presenter animates the collapse asynchronously after
             // returning, `current` is already `nil` for the tail of that animation and
-            // the host shows idle home content underneath. That is acceptable — the card
-            // covers the claim handoff, which is the visible part — but it is not the
+            // the host shows idle home content underneath. That is acceptable - the card
+            // covers the claim handoff, which is the visible part - but it is not the
             // "card renders through the entire collapse" an earlier comment promised.
             await presenter.endTransientPresentation(token)
             activeToken = nil
@@ -208,7 +208,7 @@ public final class NookActivityQueue: ObservableObject {
     /// Appended, not front-inserted: ``dequeue()`` picks the *first* element of the
     /// highest priority, so appending puts the rejected item behind any same-priority
     /// peers that were already waiting. That preserves FIFO order within a priority
-    /// class — a peer enqueued before the takeover still gets its turn first, the
+    /// class - a peer enqueued before the takeover still gets its turn first, the
     /// retry happens after. A higher-priority enqueue arriving during the contention
     /// backoff still preempts (dequeue's max-priority pass picks it first).
     private func requeue(_ activity: NookActivity) {
@@ -225,12 +225,12 @@ public final class NookActivityQueue: ObservableObject {
     }
 
     /// Suspends the drain loop while the user is engaging the surface, returning once
-    /// they disengage — or promptly when the queue is suspended or the drain task is
+    /// they disengage - or promptly when the queue is suspended or the drain task is
     /// cancelled.
     ///
     /// This polls rather than awaiting `userEngagementChanges` directly. That publisher
     /// collapses duplicates, so a `for await` over it parks until the *next distinct*
-    /// value arrives — and a `suspend()`/teardown that cancels the drain task while the
+    /// value arrives - and a `suspend()`/teardown that cancels the drain task while the
     /// user stays engaged would never wake it. `Task.sleep` throws `CancellationError`
     /// the instant the task is cancelled, so the wait can never outlive its task.
     private func waitWhileUserEngaged(_ presenter: any NookSurfacePresenting) async {

--- a/Sources/NookComponents/Shelf/NookShelfView.swift
+++ b/Sources/NookComponents/Shelf/NookShelfView.swift
@@ -9,13 +9,13 @@ import AppKit
 import NookKit
 import SwiftUI
 
-/// The file-shelf surface. Register it as a host home view — either as the whole home
+/// The file-shelf surface. Register it as a host home view - either as the whole home
 /// view (`NookApp.main { NookShelfView(store: shelf) }`) or as one section of a larger
 /// `home` content closure.
 ///
 /// Files dropped on the notch appear here once the host wires ``ShelfStore/accept(_:)``
 /// into `NookConfiguration.onFileDrop`. Each shelved file can be dragged back out to
-/// Finder or another app via a file-promise drag source — which works from the notch's
+/// Finder or another app via a file-promise drag source - which works from the notch's
 /// non-activating panel, satisfies receivers that demand file promises, and brackets
 /// security-scoped access for sandboxed reads.
 public struct NookShelfView: View {

--- a/Sources/NookComponents/Shelf/ShelfDragSource.swift
+++ b/Sources/NookComponents/Shelf/ShelfDragSource.swift
@@ -16,7 +16,7 @@ import UniformTypeIdentifiers
 ///
 /// 1. The shelf lives on a `.nonactivatingPanel`. Drags originated from a SwiftUI
 ///    hosting view inside such a panel often fail when the pasteboard item is bound
-///    to the view's window lifetime — a deferred file representation registers
+///    to the view's window lifetime - a deferred file representation registers
 ///    cheaply at drag-start and runs the file write only when the receiver accepts.
 /// 2. Receivers that demand file *promises* (Mail compose, web upload widgets, many
 ///    sandboxed apps) reject contents-of providers but accept a promise.
@@ -78,7 +78,7 @@ func writeShelfItem(_ item: ShelfItem, to destination: URL) -> Error? {
 /// on the destination name), copies the contents under scope, and hands the URL to
 /// the system.
 ///
-/// Staging via `FileManager.url(for: .itemReplacementDirectory, …)` rather than a
+/// Staging via `FileManager.url(for: .itemReplacementDirectory, ...)` rather than a
 /// `nook-shelf-out-<UUID>` directory under `temporaryDirectory`: the
 /// `itemReplacementDirectory` is the OS-blessed staging area for "move into place"
 /// operations, and macOS reaps it aggressively after the receiver consumes the file.
@@ -91,7 +91,7 @@ func makeShelfDragItemProvider(for item: ShelfItem) -> NSItemProvider {
     let provider = NSItemProvider()
     provider.suggestedName = item.displayName
 
-    // Capture by value — `ShelfItem` is `Sendable`. The closure must not capture the
+    // Capture by value - `ShelfItem` is `Sendable`. The closure must not capture the
     // host SwiftUI view or any actor-isolated state.
     let captured = item
 
@@ -121,7 +121,7 @@ func makeShelfDragItemProvider(for item: ShelfItem) -> NSItemProvider {
         if let error = writeShelfItem(captured, to: destination) {
             completionHandler(nil, false, error)
         } else {
-            // `coordinated: false` — the staging file needs no NSFileCoordinator
+            // `coordinated: false` - the staging file needs no NSFileCoordinator
             // brokering for the receiver to read it. macOS reaps the item-replacement
             // directory once the receiver consumes the promise.
             completionHandler(destination, false, nil)

--- a/Sources/NookComponents/Shelf/ShelfItem.swift
+++ b/Sources/NookComponents/Shelf/ShelfItem.swift
@@ -25,8 +25,8 @@ import UniformTypeIdentifiers
 /// of silently corroding the shelf. Items persisted by older builds decode with
 /// ``BookmarkKind/unknown`` and are treated like `.nonScoped` for purge purposes.
 ///
-/// Under the App Sandbox, *touching the file's contents* — not just resolving the
-/// bookmark — requires bracketing the access with
+/// Under the App Sandbox, *touching the file's contents* - not just resolving the
+/// bookmark - requires bracketing the access with
 /// `startAccessingSecurityScopedResource()`/`stopAccessingSecurityScopedResource()`.
 /// Use ``withResolvedURL(_:)`` for any synchronous read; it does the bracketing.
 /// `resolveURL()` is for path-level use only (display, comparison) and does **not**
@@ -35,7 +35,7 @@ import UniformTypeIdentifiers
 public struct ShelfItem: Identifiable, Codable, Hashable, Sendable {
     /// Stable id minted at shelf-add time. Never reused; survives bookmark re-capture.
     public let id: UUID
-    /// File name without extension — what the chip label shows.
+    /// File name without extension - what the chip label shows.
     public let displayName: String
     /// File extension without the leading dot, e.g. `"pdf"`. Empty for extensionless files.
     public let fileExtension: String
@@ -52,12 +52,12 @@ public struct ShelfItem: Identifiable, Codable, Hashable, Sendable {
 
     /// How a bookmark was captured.
     ///
-    /// - `scoped`: a `.withSecurityScope` bookmark — durable across launches under the
+    /// - `scoped`: a `.withSecurityScope` bookmark - durable across launches under the
     ///   App Sandbox.
     /// - `nonScoped`: a plain bookmark. Resolves fine outside the sandbox; **cannot**
     ///   resolve in a future sandboxed launch.
     /// - `unknown`: persisted by a build that predates this tag. Treated like
-    ///   `.nonScoped` for purge — preserved when it fails to resolve.
+    ///   `.nonScoped` for purge - preserved when it fails to resolve.
     public enum BookmarkKind: String, Codable, Sendable, CaseIterable {
         case scoped
         case nonScoped
@@ -82,8 +82,8 @@ public struct ShelfItem: Identifiable, Codable, Hashable, Sendable {
     }
 
     /// Resolves the bookmark to a current URL, or `nil` if the file can no longer be
-    /// reached. A `nil` here is **not** proof the file was deleted — under the App
-    /// Sandbox it can also mean access was lost — so callers must not treat it as a
+    /// reached. A `nil` here is **not** proof the file was deleted - under the App
+    /// Sandbox it can also mean access was lost - so callers must not treat it as a
     /// deletion signal (see ``ShelfStore/purgeMissing()``).
     ///
     /// This does **not** start security-scoped access. It is for path-level use
@@ -94,12 +94,12 @@ public struct ShelfItem: Identifiable, Codable, Hashable, Sendable {
     }
 
     /// Resolves the bookmark and runs `body` with security-scoped access active for the
-    /// call's duration — started before `body`, stopped after (a no-op for plain
+    /// call's duration - started before `body`, stopped after (a no-op for plain
     /// bookmarks and non-sandboxed hosts). Returns `nil`, without calling `body`, if the
     /// bookmark can't be resolved.
     ///
     /// Use this for any *synchronous* file read (icon, attributes, contents). It is not
-    /// suitable for work that outlives the call — e.g. an asynchronous drag session —
+    /// suitable for work that outlives the call - e.g. an asynchronous drag session - 
     /// because access stops as soon as `body` returns.
     public func withResolvedURL<T>(_ body: (URL) -> T) -> T? {
         guard let url = resolved()?.url else { return nil }
@@ -129,7 +129,7 @@ public struct ShelfItem: Identifiable, Codable, Hashable, Sendable {
 
     /// Returns a copy whose bookmark has been re-captured from `url`, or `nil` if a fresh
     /// bookmark can't be made. The caller supplies the already-resolved URL so a heal
-    /// pass doesn't resolve the bookmark a second time — see ``ShelfStore``.
+    /// pass doesn't resolve the bookmark a second time - see ``ShelfStore``.
     ///
     /// Re-capture is also a natural moment to **upgrade** a `.nonScoped`/`.unknown` item
     /// to `.scoped` when scoped capture now succeeds (e.g. the host left the sandbox
@@ -179,7 +179,7 @@ public struct ShelfItem: Identifiable, Codable, Hashable, Sendable {
     }
 
     /// Custom decoder so JSON written by an older build (no `bookmarkKind` field)
-    /// decodes cleanly to `.unknown` — which the purge rule treats as a non-scoped
+    /// decodes cleanly to `.unknown` - which the purge rule treats as a non-scoped
     /// bookmark, preserving it across launches. Same pattern as
     /// ``NookAppearancePreferences``.
     public init(from decoder: Decoder) throws {

--- a/Sources/NookComponents/Shelf/ShelfRuntime.swift
+++ b/Sources/NookComponents/Shelf/ShelfRuntime.swift
@@ -10,20 +10,20 @@ import os
 
 /// Small capability probes the shelf consults at runtime.
 ///
-/// Kept in its own type — and not on `ShelfStore` — so the App Sandbox check is
+/// Kept in its own type - and not on `ShelfStore` - so the App Sandbox check is
 /// reachable from any shelf code (the drag-out delegate, future per-item probes)
 /// without taking an actor hop into the store.
 public enum ShelfRuntime {
     /// `true` when the host is running under the App Sandbox.
     ///
     /// Uses the `APP_SANDBOX_CONTAINER_ID` environment variable that the system sets
-    /// on every sandboxed process — the canonical macOS signal. Cheap and safe to call
+    /// on every sandboxed process - the canonical macOS signal. Cheap and safe to call
     /// from any thread; the result cannot change over a process's lifetime.
     public static let isSandboxed: Bool = {
         ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] != nil
     }()
 
     /// The shelf's OS-level logger. Use for one-shot diagnostics that a host can grep
-    /// for in `log show` — not for noisy per-event logging.
+    /// for in `log show` - not for noisy per-event logging.
     static let log = Logger(subsystem: "dev.opennook.shelf", category: "ShelfStore")
 }

--- a/Sources/NookComponents/Shelf/ShelfStore.swift
+++ b/Sources/NookComponents/Shelf/ShelfStore.swift
@@ -15,7 +15,7 @@ import Foundation
 /// dropping any items whose files have since disappeared.
 ///
 /// `@MainActor`-isolated: the `@Published` `items` drives SwiftUI, and every mutation
-/// path arrives on the main actor — file drops are delivered by the (main-actor) `Nook`
+/// path arrives on the main actor - file drops are delivered by the (main-actor) `Nook`
 /// surface, and SwiftUI interactions are main-actor by definition. This matches the
 /// concurrency contract of `NookActivityQueue`.
 @MainActor
@@ -26,7 +26,7 @@ public final class ShelfStore: ObservableObject {
     /// How strictly ``accept(_:)`` treats non-scoped bookmark captures.
     ///
     /// - ``lenient``: the default. Accept a non-scoped bookmark even under the App
-    ///   Sandbox — the purge rule will preserve it across launches, so the user keeps
+    ///   Sandbox - the purge rule will preserve it across launches, so the user keeps
     ///   the entry even though it won't resolve in a sandboxed reload.
     /// - ``strict``: under the App Sandbox, refuse to accept an item whose scoped
     ///   capture failed. Better than silently degrading when the host wants drops to
@@ -49,7 +49,7 @@ public final class ShelfStore: ObservableObject {
 
     /// - Parameters:
     ///   - persistenceKey: `UserDefaults` key the encoded shelf is stored under.
-    ///   - defaults: the `UserDefaults` instance — injectable for tests.
+    ///   - defaults: the `UserDefaults` instance - injectable for tests.
     ///   - acceptanceMode: see ``AcceptanceMode``; defaults to `.lenient`.
     public init(
         persistenceKey: String = "nook.shelf.items",
@@ -63,20 +63,20 @@ public final class ShelfStore: ObservableObject {
     }
 
     /// Adds files to the shelf, skipping any already present (compared by resolved path).
-    /// Drop-in for `NookConfiguration.onFileDrop` — returns `true` if at least one file
+    /// Drop-in for `NookConfiguration.onFileDrop` - returns `true` if at least one file
     /// was added, which keeps the nook expanded so the shelf is visible.
     ///
     /// Under the App Sandbox in ``AcceptanceMode/strict`` mode, items whose scoped
     /// bookmark capture failed are dropped silently (returned `false` if no items
     /// remain). In `.lenient` (the default) such items are accepted with a
-    /// `.nonScoped` tag — the purge rule will preserve them across launches.
+    /// `.nonScoped` tag - the purge rule will preserve them across launches.
     @discardableResult
     public func accept(_ urls: [URL]) -> Bool {
         // Dedup is a *path-level* comparison, so `resolveURL()` (no security scope) is
-        // the right call here — and is deliberately not wrapped in `withResolvedURL`.
+        // the right call here - and is deliberately not wrapped in `withResolvedURL`.
         // Per `ShelfItem`'s contract, security-scoped access is only needed to touch a
         // file's *contents*; resolving a bookmark to a URL for comparison does not need
-        // it. Bracketing here would start/stop scoped access for no read — pure overhead.
+        // it. Bracketing here would start/stop scoped access for no read - pure overhead.
         let existing = Set(items.compactMap { $0.resolveURL()?.standardizedFileURL.path })
         let candidates = urls
             .filter { !existing.contains($0.standardizedFileURL.path) }
@@ -87,7 +87,7 @@ public final class ShelfStore: ObservableObject {
         case .lenient:
             admitted = candidates
         case .strict:
-            // Under the sandbox, a non-scoped capture is a durability bomb — refuse it.
+            // Under the sandbox, a non-scoped capture is a durability bomb - refuse it.
             // Outside the sandbox, a non-scoped fallback is fine and admitted normally.
             admitted = ShelfRuntime.isSandboxed
                 ? candidates.filter { $0.bookmarkKind == .scoped }
@@ -137,18 +137,18 @@ public final class ShelfStore: ObservableObject {
     /// 1. **Per-item ambiguity (non-scoped bookmark under the sandbox).** A
     ///    `.nonScoped` or `.unknown` bookmark cannot resolve in a sandboxed launch
     ///    even when the file is right there. So these items are **never purged** on
-    ///    resolution failure — they remain on the shelf and may resolve in a later
+    ///    resolution failure - they remain on the shelf and may resolve in a later
     ///    non-sandboxed launch, or get upgraded by a re-add. Only `.scoped` items can
     ///    be purged.
     /// 2. **Systemic ambiguity (everything fails).** Even among `.scoped` items, if
-    ///    *every* resolvable candidate fails — indistinguishable from a sandboxed host
-    ///    losing its grant entirely — nothing is dropped.
+    ///    *every* resolvable candidate fails - indistinguishable from a sandboxed host
+    ///    losing its grant entirely - nothing is dropped.
     public func purgeMissing() {
         guard !items.isEmpty else { return }
         let resolutions = items.map { ($0, $0.resolveURL()) }
         let resolvable = resolutions.filter { $0.0.bookmarkKind == .scoped }
         // Systemic-failure guard: only drop scoped items when at least one scoped item
-        // resolved. Otherwise the failure is plausibly a lost grant — preserve it all.
+        // resolved. Otherwise the failure is plausibly a lost grant - preserve it all.
         guard resolvable.contains(where: { $0.1 != nil }) else { return }
 
         let before = items.count
@@ -173,7 +173,7 @@ public final class ShelfStore: ObservableObject {
     ///   stops resolving. Re-capture also **upgrades** a `.nonScoped`/`.unknown` item
     ///   to `.scoped` when scoped capture now succeeds.
     /// - **Purge:** an item whose bookmark fails to resolve is a *candidate* for
-    ///   removal — but only if it was `.scoped` and a sibling `.scoped` item still
+    ///   removal - but only if it was `.scoped` and a sibling `.scoped` item still
     ///   resolves. `.nonScoped` and `.unknown` items are always preserved on
     ///   resolution failure (see ``purgeMissing()``).
     ///
@@ -196,7 +196,7 @@ public final class ShelfStore: ObservableObject {
             return (item, true, false)
         }
 
-        // Among scoped items, purge only when at least one scoped sibling resolved —
+        // Among scoped items, purge only when at least one scoped sibling resolved - 
         // systemic failure preserves everything. Non-scoped/unknown items are always
         // preserved on failure.
         let anyScopedResolved = reconciled.contains { $0.item.bookmarkKind == .scoped && $0.resolved }

--- a/Sources/NookComponents/Volume/NookVolumeIndicator.swift
+++ b/Sources/NookComponents/Volume/NookVolumeIndicator.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// configuration.setCompactTrailing { NookVolumeIndicator(observer: volume) }
 /// ```
 ///
-/// It is *ambient* — it shows the level, it does not intercept or replace Apple's
+/// It is *ambient* - it shows the level, it does not intercept or replace Apple's
 /// volume HUD. Reads `\.nookResolvedTheme` from the environment for its tint.
 public struct NookVolumeIndicator: View {
     @ObservedObject private var observer: SystemVolumeObserver

--- a/Sources/NookComponents/Volume/SystemVolumeObserver.swift
+++ b/Sources/NookComponents/Volume/SystemVolumeObserver.swift
@@ -12,7 +12,7 @@ import Foundation
 /// The device/volume/mute reads ``SystemVolumeObserver`` depends on.
 ///
 /// Factored behind a protocol so the observer's CoreAudio dependency is an injectable
-/// seam — production uses ``CoreAudioVolumeReader``; tests pass a fake so the
+/// seam - production uses ``CoreAudioVolumeReader``; tests pass a fake so the
 /// default-device rebind, the main-element-vs-per-channel fallback, mute reads, and
 /// clamping can all be exercised without a live audio device. This mirrors the
 /// injectable `sleep` closure on `NookActivityQueue`.
@@ -23,7 +23,7 @@ public protocol VolumeReading: Sendable {
     /// The current default output device, or `nil` when none is available.
     func defaultOutputDevice() -> AudioDeviceID?
 
-    /// The device's output volume — `nil` when neither a main-element scalar nor any
+    /// The device's output volume - `nil` when neither a main-element scalar nor any
     /// per-channel scalar can be read. Not required to be clamped; the observer clamps.
     func readVolume(_ device: AudioDeviceID) -> Double?
 
@@ -33,7 +33,7 @@ public protocol VolumeReading: Sendable {
 
 /// Observes the system's default-output-device volume and mute state.
 ///
-/// Built entirely on public CoreAudio property listeners — no private API, no special
+/// Built entirely on public CoreAudio property listeners - no private API, no special
 /// entitlement, App Store-safe. It tracks the *default output device* and re-binds when
 /// that changes (headphones plugged in, an output switched in Control Center), so the
 /// reported level always follows wherever sound is going.
@@ -55,7 +55,7 @@ public final class SystemVolumeObserver: ObservableObject {
 
     private var deviceID = AudioObjectID(kAudioObjectUnknown)
 
-    /// The injectable read seam — real CoreAudio in production, a fake in tests.
+    /// The injectable read seam - real CoreAudio in production, a fake in tests.
     private let reader: VolumeReading
 
     /// CoreAudio listener block type. `AudioObjectPropertyListenerBlock` is imported
@@ -74,7 +74,7 @@ public final class SystemVolumeObserver: ObservableObject {
 
     /// Internal counters: number of `AudioObjectAddPropertyListenerBlock` and
     /// `AudioObjectRemovePropertyListenerBlock` calls the observer has made over its
-    /// lifetime. Used by the test suite to verify add/remove balance — every Add must
+    /// lifetime. Used by the test suite to verify add/remove balance - every Add must
     /// be paired with a Remove. Atomic-int-safe because the observer is `@MainActor`
     /// and all mutations are on the main actor.
     var addedListenerCountForTesting: Int = 0
@@ -85,7 +85,7 @@ public final class SystemVolumeObserver: ObservableObject {
     public init(reader: VolumeReading = CoreAudioVolumeReader()) {
         self.reader = reader
         // `init` runs on the main actor (the type is `@MainActor`-isolated), so the
-        // binding below — which writes `@Published` state — is already correct. The
+        // binding below - which writes `@Published` state - is already correct. The
         // CoreAudio listener blocks registered here are dispatched on the main queue and
         // hop back to the main actor before mutating anything; no `Thread.isMainThread`
         // guard is needed now that the isolation is real and enforced by the compiler.
@@ -96,7 +96,7 @@ public final class SystemVolumeObserver: ObservableObject {
     deinit {
         // `deinit` is non-isolated and may run on any thread. It is sound regardless:
         // `AudioObjectRemovePropertyListenerBlock` is itself thread-safe, and the
-        // listener/device state read here is only ever written on the main actor — once
+        // listener/device state read here is only ever written on the main actor - once
         // the last reference is gone no listener block can still be racing this. The
         // listener removal is inlined here (rather than calling the main-actor
         // `removeDeviceListeners()`) precisely because `deinit` is non-isolated.
@@ -128,7 +128,7 @@ public final class SystemVolumeObserver: ObservableObject {
     }
 
     /// Test-only seam: runs the same listener teardown `deinit` does, but on the
-    /// main actor so it can bump the test counters. Idempotent — calling it twice
+    /// main actor so it can bump the test counters. Idempotent - calling it twice
     /// will only decrement once for any listener it actually removed.
     func tearDownForTesting() {
         removeDeviceListeners()
@@ -219,7 +219,7 @@ public final class SystemVolumeObserver: ObservableObject {
     // MARK: - Property addresses
 
     /// `nonisolated` so the non-isolated `deinit` and the `Sendable`
-    /// ``CoreAudioVolumeReader`` can both build addresses — the function is pure.
+    /// ``CoreAudioVolumeReader`` can both build addresses - the function is pure.
     nonisolated static func address(
         _ selector: AudioObjectPropertySelector,
         _ scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal
@@ -248,7 +248,7 @@ func resolveVolumeFallback(mainScalar: Double?, channelScalars: [Double]) -> Dou
     return channelScalars.reduce(0, +) / Double(channelScalars.count)
 }
 
-/// The production ``VolumeReading`` — talks to CoreAudio directly. Stateless and
+/// The production ``VolumeReading`` - talks to CoreAudio directly. Stateless and
 /// `Sendable`, so it is safe to capture into the observer's listener blocks.
 public struct CoreAudioVolumeReader: VolumeReading {
     public init() {}
@@ -263,14 +263,14 @@ public struct CoreAudioVolumeReader: VolumeReading {
         return status == noErr && device != AudioObjectID(kAudioObjectUnknown) ? device : nil
     }
 
-    /// Reads the device's output volume — the main-element scalar if it has one,
+    /// Reads the device's output volume - the main-element scalar if it has one,
     /// otherwise the average of every per-channel scalar the device advertises. The
     /// main-vs-channel decision is delegated to
     /// ``resolveVolumeFallback(mainScalar:channelScalars:)``.
     ///
     /// The per-channel pass enumerates the channels from the device's actual output
     /// stream configuration (``outputChannelCount(for:)``) rather than the previous
-    /// hard-coded `{1, 2}` — a 5.1 or 7.1 device's volume control lives on channels
+    /// hard-coded `{1, 2}` - a 5.1 or 7.1 device's volume control lives on channels
     /// 3-6 (center, LFE, rears) and the old probe missed them entirely.
     public func readVolume(_ device: AudioDeviceID) -> Double? {
         var mainScalar: Double?
@@ -287,7 +287,7 @@ public struct CoreAudioVolumeReader: VolumeReading {
 
         var channelScalars: [Double] = []
         let channelCount = Self.outputChannelCount(for: device)
-        // Probe at least channels 1+2 — even when the stream-configuration probe fails
+        // Probe at least channels 1+2 - even when the stream-configuration probe fails
         // or reports zero, stereo is the common case and we want the fallback path
         // unchanged for it.
         let upperBound = max(channelCount, 2)

--- a/Sources/NookExecutable/main.swift
+++ b/Sources/NookExecutable/main.swift
@@ -7,7 +7,7 @@
 
 // SPM trampoline. `swift run Nook` builds this target and immediately
 // hands off to the shared library entry point in `NookApp`. The Xcode app
-// target uses `App/main.swift`, which is identical — both keep behavior in one
+// target uses `App/main.swift`, which is identical - both keep behavior in one
 // place so the headless dev loop and the bundled-app launch can never diverge.
 //
 // Note: the SPM-built binary has no `Contents/Info.plist` on disk, so it runs

--- a/Sources/NookKit/App/AppCoordinator.swift
+++ b/Sources/NookKit/App/AppCoordinator.swift
@@ -15,12 +15,12 @@ import SwiftUI
 /// and the menu-bar fallback call into.
 ///
 /// `@MainActor`-isolated: the coordinator drives `Nook`/`NSWindow` chrome, holds the
-/// `@Published` ``AppState``, and arbitrates transient surface presenters — every one
+/// `@Published` ``AppState``, and arbitrates transient surface presenters - every one
 /// of which is main-actor work. Conforms to ``NookSurfacePresenting`` so transient
 /// presenters (e.g. ``NookActivityQueue``) can take over the surface through it.
 @MainActor
 public final class AppCoordinator: ObservableObject {
-    /// Framework-global, observable chrome state — appearance preferences, hotkey,
+    /// Framework-global, observable chrome state - appearance preferences, hotkey,
     /// display preference, visibility mirror, view mode.
     public let appState: AppState
 
@@ -52,7 +52,7 @@ public final class AppCoordinator: ObservableObject {
     }
     var accessibilityObserver: ObserverToken?
 
-    /// Arbitrates the surface between competing transient presenters — the activity
+    /// Arbitrates the surface between competing transient presenters - the activity
     /// queues and ambient indicators of every loaded module. Lazy because it captures
     /// `surface`; layered over ``enqueueLifecycle`` so it serializes nothing itself.
     lazy var arbiter: SurfaceArbiter = {
@@ -73,12 +73,12 @@ public final class AppCoordinator: ObservableObject {
     /// duplicate observers, sinks, and `onReady` callbacks.
     private var hasStarted = false
 
-    /// User-initiated open intent — `true` from the moment the user opens the surface
+    /// User-initiated open intent - `true` from the moment the user opens the surface
     /// (toggleNook / showNook / showHome / showSettings) until it leaves `.expanded`
     /// for any reason. Drives ``isUserEngaged`` together with `surface.isHovering`.
     ///
     /// This is *intent*, not a mirror of surface state. The arbiter's own `expand()`
-    /// flips the surface to `.expanded` but does NOT set this flag — so a later
+    /// flips the surface to `.expanded` but does NOT set this flag - so a later
     /// higher-priority claim can preempt without the gate falsely tripping. The old
     /// model (engagement = `isNookVisible || isHovering`) had exactly that bug,
     /// because the mirror flipped from the arbiter's own expand and silently
@@ -108,19 +108,19 @@ public final class AppCoordinator: ObservableObject {
     }
 
     /// Module ids whose `onReady` has already fired. A module's `onReady` runs once per
-    /// *loaded instance* — when it is unloaded (`unloadOnSwitchAway`) the id is dropped
+    /// *loaded instance* - when it is unloaded (`unloadOnSwitchAway`) the id is dropped
     /// so a rebuilt instance gets a fresh `onReady` (e.g. to re-bind an activity queue).
     private var modulesGivenOnReady: Set<String> = []
 
     /// Tail of the serial chain that all surface lifecycle transitions
-    /// (expand/compact/hide) run through. Without this, two rapid triggers — a
-    /// double hotkey press, a display change landing mid-show — each spawn an
+    /// (expand/compact/hide) run through. Without this, two rapid triggers - a
+    /// double hotkey press, a display change landing mid-show - each spawn an
     /// independent `Task` whose `await`s interleave, settling the surface in the
     /// opposite state from the user's last action.
     private var lifecycleTail: Task<Void, Never>?
 
     /// Tail of the *off-chain* switch-quiesce drains. A module switch flips identity
-    /// inside the serial lifecycle chain (fast — no user-visible stall) and runs the
+    /// inside the serial lifecycle chain (fast - no user-visible stall) and runs the
     /// outgoing module's `prepareForSwitchAway` in a detached follow-on task: the
     /// arbiter's `invalidateClaims` already makes the outgoing module's surface
     /// activity stale-token-safe, so the user sees the new module immediately and the
@@ -129,17 +129,17 @@ public final class AppCoordinator: ObservableObject {
     private var switchTailTask: Task<Void, Never>?
 
     /// Bounded budget for an outgoing module's `prepareForSwitchAway`. A misbehaving
-    /// module that never returns is logged and the task is cancelled — the arbiter's
+    /// module that never returns is logged and the task is cancelled - the arbiter's
     /// stale-token guard makes the abandoned drain a no-op on the surface.
     static let switchAwayTimeout: Duration = .seconds(2)
 
-    /// Awaits the current tail of the serial lifecycle chain — every transition and
+    /// Awaits the current tail of the serial lifecycle chain - every transition and
     /// switch transaction enqueued so far has settled when this returns. Test-only seam.
     func drainLifecycleForTesting() async {
         await lifecycleTail?.value
     }
 
-    /// Awaits all in-flight detached switch-quiesce drains. Test-only seam — production
+    /// Awaits all in-flight detached switch-quiesce drains. Test-only seam - production
     /// code never reads this because the arbiter already guarantees stale-token safety.
     func drainSwitchTailsForTesting() async {
         await switchTailTask?.value
@@ -176,7 +176,7 @@ public final class AppCoordinator: ObservableObject {
     /// Builds the production `Nook` surface with the coordinator's router views.
     ///
     /// The router views capture `moduleHost`/`appState` and weak callbacks onto a
-    /// coordinator that does not exist yet at call time — they are wired with a
+    /// coordinator that does not exist yet at call time - they are wired with a
     /// `coordinatorBox` that the designated `init` fills in once `self` is available.
     static func makeDefaultNook(
         moduleHost: ModuleHost,
@@ -223,7 +223,7 @@ public final class AppCoordinator: ObservableObject {
         weak var coordinator: AppCoordinator?
     }
 
-    /// Single-module convenience — wraps `configuration` as a lone-module ``ModuleHost``
+    /// Single-module convenience - wraps `configuration` as a lone-module ``ModuleHost``
     /// so a downstream that just wants a coordinator for one ``NookConfiguration`` does
     /// not have to construct the host plumbing manually.
     public convenience init(
@@ -238,7 +238,7 @@ public final class AppCoordinator: ObservableObject {
         )
     }
 
-    /// Multi-module entry — pass a fully built ``ModuleHost`` (e.g. from
+    /// Multi-module entry - pass a fully built ``ModuleHost`` (e.g. from
     /// `NookHostConfiguration.makeRegistry()`).
     public convenience init(
         appState: AppState = AppState(),
@@ -278,7 +278,7 @@ public final class AppCoordinator: ObservableObject {
         // Bind the surface-state mirror at init, not at start: it is pure observation
         // (writes only to `appState.isNookVisible` and clears `userInitiatedOpen` on
         // independent collapse), and the arbiter's engagement bookkeeping depends on
-        // it being live from the moment the coordinator exists — including in tests
+        // it being live from the moment the coordinator exists - including in tests
         // that construct a coordinator without calling `start()`.
         bindSurfaceVisibility()
         // Likewise bind the presentation-pin projection at init: tests that exercise
@@ -289,7 +289,7 @@ public final class AppCoordinator: ObservableObject {
         coordinatorBox.coordinator = self
         // Project the active module's lifecycle callbacks onto the surface. The hooks
         // fire on the surface's own state transitions, so hover- and drag-driven changes
-        // reach the host too — not just coordinator-initiated show/hide. `performSwitch`
+        // reach the host too - not just coordinator-initiated show/hide. `performSwitch`
         // re-wires them across a module switch.
         applyModuleHooks(configuration)
     }
@@ -302,13 +302,13 @@ public final class AppCoordinator: ObservableObject {
 
     /// Brings the coordinator online: sets the activation policy, syncs the chrome
     /// backdrop, registers global hotkeys, installs the surface bindings, plays the
-    /// cold-launch shimmer, and fires the active module's `onReady`. Idempotent —
+    /// cold-launch shimmer, and fires the active module's `onReady`. Idempotent - 
     /// safe to call more than once.
     public func start() {
         guard !hasStarted else { return }
         hasStarted = true
 
-        // `NSApplication.shared` — not the `NSApp` global. The global is nil until the
+        // `NSApplication.shared` - not the `NSApp` global. The global is nil until the
         // app object is first materialized; a unit-test process that constructs the
         // coordinator without ever calling `NSApplication.shared.run()` traps on
         // `NSApp.setActivationPolicy`. The shared accessor materializes lazily.
@@ -322,7 +322,7 @@ public final class AppCoordinator: ObservableObject {
         registerModuleHotkeys()
         bindHotkeyRegistration()
         bindNookDragSession()
-        // `bindSurfaceVisibility` was moved to `init` — it must be live before any
+        // `bindSurfaceVisibility` was moved to `init` - it must be live before any
         // arbiter claim is granted, including in tests that don't call `start()`.
 
         // Cold-launch greeting: compact the chrome, then fire a one-shot shimmer along the
@@ -330,7 +330,7 @@ public final class AppCoordinator: ObservableObject {
         // nook into a visible state so the event fires immediately instead of queuing.
         //
         // The cold-launch compact suppresses the host's `onCompact` hook for this one
-        // transition — it is a boot artifact, not a user-driven collapse, and a host
+        // transition - it is a boot artifact, not a user-driven collapse, and a host
         // wiring `onCompact = { /* user dismissed the nook */ }` would otherwise fire
         // on launch every time. Restored synchronously inside the same serial step so
         // any subsequent hover- or coordinator-driven compact fires the hook normally.
@@ -361,12 +361,12 @@ public final class AppCoordinator: ObservableObject {
     public var activeModuleID: String { moduleHost.activeModuleID }
 
     /// Switches the foreground module. The switch is enqueued as a transaction on the
-    /// serial lifecycle chain (``enqueueLifecycle``), so it is ordered against — never
-    /// interleaved with — surface transitions and other switches.
+    /// serial lifecycle chain (``enqueueLifecycle``), so it is ordered against - never
+    /// interleaved with - surface transitions and other switches.
     ///
     /// The transaction quiesces the outgoing module's surface activity, invalidates its
-    /// arbiter claims, flips module identity, re-wires the surface hooks, and — when the
-    /// surface is already expanded — fires a synthetic `onExpand` for the incoming
+    /// arbiter claims, flips module identity, re-wires the surface hooks, and - when the
+    /// surface is already expanded - fires a synthetic `onExpand` for the incoming
     /// module. The content cross-fades in place; the surface is not hidden, so the
     /// outgoing module gets `onDeactivate` (via `ModuleHost`) but not `onHide`.
     public func switchModule(to id: String) {
@@ -377,12 +377,12 @@ public final class AppCoordinator: ObservableObject {
     /// invalidate-first so a slow or misbehaving outgoing module cannot wedge the
     /// lifecycle chain.
     ///
-    /// On the serial chain — fast, user-facing:
+    /// On the serial chain - fast, user-facing:
     ///   1. **Invalidate** outgoing module's arbiter claims (synchronous, in-memory).
     ///      After this, any `endTransientPresentation` from the outgoing module is a
-    ///      guaranteed no-op — the arbiter's `liveTokens` guard makes the outgoing
+    ///      guaranteed no-op - the arbiter's `liveTokens` guard makes the outgoing
     ///      drain stale-token-safe regardless of when it finishes.
-    ///   2. **Read live surface state** — never the mirror, never a value captured
+    ///   2. **Read live surface state** - never the mirror, never a value captured
     ///      before this transaction reached the head of the queue.
     ///   3. **Flip identity**: `onDeactivate` / `onActivate`, configuration re-publish.
     ///   4. **Re-wire surface hooks** so the synthetic `onExpand` below fires the
@@ -392,20 +392,20 @@ public final class AppCoordinator: ObservableObject {
     ///   6. **Fire `onReady`** for the incoming module (once per loaded instance).
     ///   7. **Synthesize `onExpand`** if the surface was already expanded.
     ///
-    /// Off the serial chain — bounded, under-the-covers:
+    /// Off the serial chain - bounded, under-the-covers:
     ///   8. **Drain the outgoing module's `prepareForSwitchAway`** in a detached
     ///      follow-on (`enqueueSwitchTail`) with a hard timeout. The user sees the new
     ///      module immediately; the outgoing module's quiesce runs concurrently. A
-    ///      hanging quiesce hits the timeout and is cancelled — the arbiter's
+    ///      hanging quiesce hits the timeout and is cancelled - the arbiter's
     ///      stale-token guard keeps that abandoned work harmless.
     ///
     /// Before the reorder, step 1 was an unbounded `await` on a module-supplied
-    /// `prepareForSwitchAway` — a misbehaving module wedged the entire lifecycle chain.
+    /// `prepareForSwitchAway` - a misbehaving module wedged the entire lifecycle chain.
     private func performSwitch(to id: String) async {
         let outgoingID = moduleHost.activeModuleID
         guard id != outgoingID, moduleHost.registry.descriptor(for: id) != nil else { return }
 
-        // 1. Invalidate outgoing claims FIRST — stale-token safety is now the contract
+        // 1. Invalidate outgoing claims FIRST - stale-token safety is now the contract
         //    the off-chain quiesce drain relies on.
         arbiter.invalidateClaims(ownedBy: outgoingID)
 
@@ -438,7 +438,7 @@ public final class AppCoordinator: ObservableObject {
             moduleHost.configuration.onExpand?()
         }
 
-        // 8. Quiesce drain — off the serial chain, with a hard timeout.
+        // 8. Quiesce drain - off the serial chain, with a hard timeout.
         //
         //    Capture the Sendable `outgoingID` only and re-resolve the module instance
         //    inside the closure. The drain runs on the main actor (the closure body is
@@ -446,7 +446,7 @@ public final class AppCoordinator: ObservableObject {
         //    reference would force a non-Sendable value across the `@Sendable` closure
         //    boundary for no real benefit. As a bonus, if a third rapid switch unloaded
         //    the outgoing module before the drain runs, the re-resolve returns `nil` and
-        //    the drain is a clean no-op — which is exactly what we'd want anyway.
+        //    the drain is a clean no-op - which is exactly what we'd want anyway.
         guard moduleHost.registry.isLoaded(outgoingID) else { return }
         enqueueSwitchTail { [weak self] in
             guard let self,
@@ -459,9 +459,9 @@ public final class AppCoordinator: ObservableObject {
     }
 
     /// Runs `work` under a hard deadline. Past `timeout` the work task is cancelled and
-    /// the timeout is logged via `print` — the coordinator does not fail the switch.
+    /// the timeout is logged via `print` - the coordinator does not fail the switch.
     ///
-    /// `work` is `@MainActor` because every caller in `AppCoordinator` is — most notably
+    /// `work` is `@MainActor` because every caller in `AppCoordinator` is - most notably
     /// the `prepareForSwitchAway` drain in ``performSwitch(to:)``, which calls a
     /// main-actor module method. Pinning the work closure to the main actor here lets
     /// the caller capture main-actor-isolated references (the resolved `NookModule`
@@ -473,7 +473,7 @@ public final class AppCoordinator: ObservableObject {
     /// no-op on the surface.
     ///
     /// `internal` rather than `private` so the test suite can exercise the deadline
-    /// directly with short timeouts — driving the production path via
+    /// directly with short timeouts - driving the production path via
     /// ``performSwitch(to:)`` would require waiting the full ``switchAwayTimeout``
     /// (2 s) per case.
     static func runWithTimeout(
@@ -499,7 +499,7 @@ public final class AppCoordinator: ObservableObject {
     }
 
     /// Projects a module's lifecycle hooks onto the surface. Called from initial wiring
-    /// and from the switch transaction — the single seam for hook projection.
+    /// and from the switch transaction - the single seam for hook projection.
     private func applyModuleHooks(_ configuration: NookConfiguration) {
         surface.onExpand = configuration.onExpand
         surface.onCompact = configuration.onCompact
@@ -535,7 +535,7 @@ public final class AppCoordinator: ObservableObject {
     /// chrome live when the user picks a different display in Settings.
     ///
     /// `Nook.screenProvider` is what makes the preference stick *without* an explicit
-    /// screen on every call site — the surface consults it on hover transitions and on
+    /// screen on every call site - the surface consults it on hover transitions and on
     /// display connect/disconnect too, so the disconnect fallback in
     /// ``NookScreenLocator/screen(matching:)`` flows through automatically.
     private func configureDisplayTargeting() {
@@ -551,7 +551,7 @@ public final class AppCoordinator: ObservableObject {
                 self.enqueueLifecycle { [weak self] in
                     guard let self else { return }
                     // Re-place whichever way the chrome is currently showing. A hidden
-                    // nook needs nothing — its next expand/compact rebuilds on the new
+                    // nook needs nothing - its next expand/compact rebuilds on the new
                     // screen via `screenProvider`.
                     if self.surface.state == .expanded {
                         await self.surface.expand(on: screen)
@@ -565,7 +565,7 @@ public final class AppCoordinator: ObservableObject {
 
     // MARK: - Chrome / backdrop
 
-    /// Softer springs than NookSurface's bouncy defaults — smoother expand/compact with
+    /// Softer springs than NookSurface's bouncy defaults - smoother expand/compact with
     /// less overshoot. A host can override the whole set via
     /// ``NookConfiguration/transitions``; otherwise these defaults apply.
     func configureNotchAnimations() {
@@ -670,9 +670,9 @@ public final class AppCoordinator: ObservableObject {
     /// The dedup key for the hotkey-registration sink: one *intent change* per user
     /// action, not one emission per upstream `@Published` update.
     private enum HotkeyRegistrationIntent: Equatable {
-        /// Recorder is open — live registration is suspended.
+        /// Recorder is open - live registration is suspended.
         case suspended
-        /// Recorder is closed — this hotkey should be registered.
+        /// Recorder is closed - this hotkey should be registered.
         case bound(NookHotkey)
     }
 
@@ -681,11 +681,11 @@ public final class AppCoordinator: ObservableObject {
     ///
     /// `combineLatest` emits once per upstream `@Published` change. A user finishing
     /// recording flips both `$hotkey` (new value) and `$isRecordingHotkey` (false) on
-    /// the same runloop turn — two emissions. A naive `removeDuplicates(by: ==)` on
+    /// the same runloop turn - two emissions. A naive `removeDuplicates(by: ==)` on
     /// the raw pair wouldn't dedup them (they're distinct), so the sink would unregister
     /// then re-register an extra time, recording the registration outcome twice on the
     /// durable failure channel. Mapping to a `HotkeyRegistrationIntent` collapses the
-    /// pair onto *what should happen* — and a recorder opened+cancelled without any
+    /// pair onto *what should happen* - and a recorder opened+cancelled without any
     /// key change deduces to one no-op.
     ///
     /// `internal`, not `private`, so tests can install the sink without bringing up
@@ -753,7 +753,7 @@ public final class AppCoordinator: ObservableObject {
         // Pin the window appearance first: the backdrop's visual-effect material resolves
         // against it, so a forced light/dark theme needs both to agree.
         surface.chromeAppearance = appState.appearancePreferences.chromeAppearanceOverride
-        // A host can override the appearance→backdrop mapping; the framework mapping is
+        // A host can override the appearance->backdrop mapping; the framework mapping is
         // the default. See `NookChromeBehavior.backdrop`.
         if let resolve = moduleHost.chromeBehavior.backdrop {
             surface.backdrop = resolve(appState.appearancePreferences, scheme, reduceTransparency)
@@ -767,8 +767,8 @@ public final class AppCoordinator: ObservableObject {
     }
 
     /// Mirrors the surface's live ``NookState`` onto `appState.isNookVisible`, and bounds
-    /// ``userInitiatedOpen`` by it: any independent collapse — hover-exit auto-compact,
-    /// drag dismiss, arbiter restore — cleanly clears intent without explicit teardown.
+    /// ``userInitiatedOpen`` by it: any independent collapse - hover-exit auto-compact,
+    /// drag dismiss, arbiter restore - cleanly clears intent without explicit teardown.
     ///
     /// This single sink is the only writer of `appState.isNookVisible` and the only
     /// path that clears `userInitiatedOpen` on independent collapse; the user-action
@@ -810,7 +810,7 @@ public final class AppCoordinator: ObservableObject {
         enqueueLifecycle { [weak self] in
             guard let self else { return }
             // Decide off the surface's live state *at execution time*, not the mirror
-            // and not when `toggleNook()` was called — a hover-expanded nook must
+            // and not when `toggleNook()` was called - a hover-expanded nook must
             // toggle closed even though no coordinator call opened it, and deciding
             // before the serial chain reaches us would race other queued transitions.
             if self.surface.state == .expanded {
@@ -873,7 +873,7 @@ public final class AppCoordinator: ObservableObject {
     }
 
     /// Projects the boolean "ignore hover-exit auto-compact" override onto the surface.
-    /// Internal because modules should not flip this directly — they pin and unpin
+    /// Internal because modules should not flip this directly - they pin and unpin
     /// through ``NookPresentationPinning`` (resolved from `\.appServices`), which
     /// ref-counts overlapping presenters and folds into ``isUserEngaged`` for the
     /// arbiter. This method is the broker's lone client; it is also called by
@@ -891,7 +891,7 @@ public final class AppCoordinator: ObservableObject {
     /// broker. The broker emits on 0->1 and N->0 pin-count edges; on each edge we
     /// project the boolean onto the surface via ``setStaysExpandedOverride(_:)``.
     /// The arbiter side is wired implicitly through ``isUserEngaged`` and
-    /// ``userEngagementChanges`` — both already consult `presentationPinning`.
+    /// ``userEngagementChanges`` - both already consult `presentationPinning`.
     private func bindPresentationPinning() {
         presentationPinning.pinChanges
             .receive(on: RunLoop.main)
@@ -904,8 +904,8 @@ public final class AppCoordinator: ObservableObject {
     // MARK: - Reset
 
     /// Restores appearance prefs, the global hotkey, and the display preference to their
-    /// defaults. Every reset routes through `AppState`'s guarded `replace…` path, so
-    /// persistence and observers fire exactly once per preference, in one pattern — no
+    /// defaults. Every reset routes through `AppState`'s guarded `replace...` path, so
+    /// persistence and observers fire exactly once per preference, in one pattern - no
     /// direct `appearancePreferences` assignment plus manual `NookAppearanceStore.save`.
     ///
     /// `staysExpandedOnHoverExit` is then projected from the freshly reset preference
@@ -929,8 +929,8 @@ extension AppCoordinator: NookSurfacePresenting {
     /// notch pinned via ``NookPresentationPinning``. A transient arbiter presenter
     /// pauses in any of those cases.
     ///
-    /// Sources from ``userInitiatedOpen`` (user intent) — NOT `appState.isNookVisible`
-    /// (surface mirror) — so the arbiter's own `expand()` never trips this gate on a
+    /// Sources from ``userInitiatedOpen`` (user intent) - NOT `appState.isNookVisible`
+    /// (surface mirror) - so the arbiter's own `expand()` never trips this gate on a
     /// subsequent preempting claim.
     ///
     /// **The pin disjunct closes a real hole**, not a theoretical one. A hover-opened
@@ -945,13 +945,13 @@ extension AppCoordinator: NookSurfacePresenting {
             || surface.isLayoutGraceActive
     }
 
-    /// Emits whenever ``isUserEngaged`` changes — the merge of the user-intent flag,
+    /// Emits whenever ``isUserEngaged`` changes - the merge of the user-intent flag,
     /// the surface's hover publisher, and the presentation-pin broker, deduplicated.
     ///
     /// Verified: in-tree consumers of `isUserEngaged` / `userEngagementChanges`
     /// (``NookActivityQueue/waitWhileUserEngaged(_:)`` at NookActivityQueue.swift:234,
     /// ``SurfaceArbiter``'s engagement gate at SurfaceArbiter.swift:109/198) are
-    /// idempotent under repeated same-value events — the activity queue polls in a
+    /// idempotent under repeated same-value events - the activity queue polls in a
     /// while-loop, and the arbiter consults the flag fresh on each claim. Adding a
     /// third publisher to the `combineLatest` increases emission frequency only on
     /// pin transitions, which `removeDuplicates()` collapses to the true edges.

--- a/Sources/NookKit/App/AppServices.swift
+++ b/Sources/NookKit/App/AppServices.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// A key into the per-module ``AppServices`` container.
 ///
 /// This is the SwiftUI `EnvironmentKey` pattern applied to dependency injection: a
-/// service is keyed by a *key type* it declares — not by its own runtime type — and the
+/// service is keyed by a *key type* it declares - not by its own runtime type - and the
 /// key carries a `defaultValue` so resolution is total (never optional). A module
 /// declares one key per service it offers:
 ///
@@ -29,7 +29,7 @@ public protocol ServiceKey {
     associatedtype Value
 
     /// The value ``AppServices/resolve(_:)`` returns when nothing was registered for
-    /// this key — the dependency-injection analogue of `EnvironmentKey.defaultValue`.
+    /// this key - the dependency-injection analogue of `EnvironmentKey.defaultValue`.
     static var defaultValue: Value { get }
 }
 
@@ -48,13 +48,13 @@ public protocol ServiceKey {
 /// }
 /// context.services.register(ClipboardServiceKey.self, ClipboardService())
 ///
-/// // ...a view resolves it — non-optional, falling back to the key's default:
+/// // ...a view resolves it - non-optional, falling back to the key's default:
 /// @Environment(\.appServices) private var services
 /// let clipboard = services.resolve(ClipboardServiceKey.self)
 /// ```
 ///
 /// `@MainActor`-isolated: registration happens when a module is constructed and
-/// resolution happens during view rendering — both on the main actor. The mutable
+/// resolution happens during view rendering - both on the main actor. The mutable
 /// `storage` is therefore only ever touched from one actor, which strict concurrency
 /// can now prove. `init()` is `nonisolated` (it only sets the empty dictionary) so the
 /// `EnvironmentKey.defaultValue` static can still be constructed from any context; a
@@ -95,8 +95,8 @@ public final class AppServices {
 }
 
 private struct AppServicesEnvironmentKey: EnvironmentKey {
-    // A single shared empty container. `AppServices` is a `@MainActor` class — hence
-    // `Sendable` — with a `nonisolated init`, so this static is concurrency-safe and
+    // A single shared empty container. `AppServices` is a `@MainActor` class - hence
+    // `Sendable` - with a `nonisolated init`, so this static is concurrency-safe and
     // satisfies `EnvironmentKey.defaultValue` without crossing actors.
     static let defaultValue = AppServices()
 }

--- a/Sources/NookKit/App/AppState.swift
+++ b/Sources/NookKit/App/AppState.swift
@@ -8,7 +8,7 @@
 import Combine
 import Foundation
 
-/// Which framework chrome screen is filling the expanded surface — the active module's
+/// Which framework chrome screen is filling the expanded surface - the active module's
 /// home view, or the framework Settings panel.
 ///
 /// `NookExpandedView` routes off this. When the host disabled Settings
@@ -40,7 +40,7 @@ public struct HotkeyRegistrationFailure: Equatable, Sendable {
 }
 
 /// Mutable, observable state shared between the coordinator and views.
-/// Holds chrome-level concerns (view mode, appearance, keep-open, visibility) — product
+/// Holds chrome-level concerns (view mode, appearance, keep-open, visibility) - product
 /// data lives in whatever model layer a downstream fork adds on top.
 ///
 /// **Swap point for product state.** A downstream fork that needs cross-view product
@@ -53,7 +53,7 @@ public final class AppState: ObservableObject {
     @Published public private(set) var viewMode: NookViewMode = .home
 
     /// Persisted appearance personalization (palette, surface style, presentation,
-    /// haptics, keep-open). Assigning replaces the whole value — use
+    /// haptics, keep-open). Assigning replaces the whole value - use
     /// ``replaceAppearancePreferences(_:)`` to also persist the change.
     @Published public var appearancePreferences = NookAppearancePreferences.default
 
@@ -79,25 +79,25 @@ public final class AppState: ObservableObject {
     }
 
     /// `true` while the nook surface is expanded. This is a read-only mirror of the
-    /// surface's own ``NookState`` — the coordinator binds it to `Nook.$state`, so it
+    /// surface's own ``NookState`` - the coordinator binds it to `Nook.$state`, so it
     /// stays accurate for hover- and drag-driven transitions too, not just
     /// coordinator-initiated show/hide. Drive visibility through ``AppCoordinator``,
     /// never by writing this.
     ///
     /// This is purely a view-model mirror. It is NOT consulted by the surface arbiter
-    /// to decide "is the user engaged" — see ``AppCoordinator/isUserEngaged``, which
+    /// to decide "is the user engaged" - see ``AppCoordinator/isUserEngaged``, which
     /// reads an explicit user-intent flag to avoid mistaking the arbiter's own expand
     /// for user engagement.
     @Published public internal(set) var isNookVisible = false
 
-    /// Transient status channel — a short-lived ``NookStatus`` (message + severity) tied
+    /// Transient status channel - a short-lived ``NookStatus`` (message + severity) tied
     /// to a single nook session. Cleared by ``resetTransientStatus()`` on every
     /// show/toggle. Hotkey-registration failures must NOT live here: they outlive a nook
     /// session and need to stay visible until the registration is fixed. Those use
     /// ``hotkeyRegistrationFailures`` instead.
     @Published public var status: NookStatus?
 
-    /// Back-compatible string view of ``status`` — reading returns the current message,
+    /// Back-compatible string view of ``status`` - reading returns the current message,
     /// writing posts an `.error`-severity status (and `nil` clears it). Prefer
     /// ``showStatus(_:severity:)`` to post non-error severities.
     public var errorMessage: String? {
@@ -117,7 +117,7 @@ public final class AppState: ObservableObject {
     /// ``resetTransientStatus()``: a failed registration stays surfaced until that
     /// registration actually succeeds (or the offending hotkey is changed), at which
     /// point the coordinator clears that id's entry. Each entry reflects the CURRENT
-    /// outcome of its registration — not a last-writer-wins shared string.
+    /// outcome of its registration - not a last-writer-wins shared string.
     @Published public internal(set) var hotkeyRegistrationFailures: [String: HotkeyRegistrationFailure] = [:]
 
     /// Records the outcome of one hotkey registration attempt: `failure` non-nil keeps
@@ -136,19 +136,19 @@ public final class AppState: ObservableObject {
     @Published public var isRecordingHotkey = false
 
     /// Mirrors `Nook.isDragInFlight`. `true` while a system file-drag session is over the
-    /// panel — kept as a hook-point for downstream consumers that want drop targets.
+    /// panel - kept as a hook-point for downstream consumers that want drop targets.
     @Published public var isDragInFlight: Bool = false
 
     /// Optional secondary label rendered in the top bar after the leading title
     /// (`[icon] Module  ›  Breadcrumb`). Modules use this to surface the current
-    /// drill-down context — a selected deck, an open document, a chosen profile
-    /// — so the chrome reflects what the user is actually looking at, instead of
+    /// drill-down context - a selected deck, an open document, a chosen profile
+    /// - so the chrome reflects what the user is actually looking at, instead of
     /// the module's static name. Set to `nil` to clear.
     ///
     /// The chrome treats this as a soft state hint: it doesn't affect ``viewMode``
     /// or the back-to-home affordance. A module that wants the breadcrumb to be
     /// clickable (e.g. "click to pop back one level") owns that interaction
-    /// inside its own surface — the chrome only renders the text.
+    /// inside its own surface - the chrome only renders the text.
     @Published public var moduleBreadcrumb: String?
 
     /// Loads the persisted appearance, hotkey, and display preferences from
@@ -160,7 +160,7 @@ public final class AppState: ObservableObject {
     /// Loads the persisted appearance, hotkey, and display preferences from
     /// `UserDefaults`, falling back to the host's launch *seed* (rather than the
     /// framework `.default`) for any entry that has never been persisted. See
-    /// ``NookPreferenceDefaults`` for the seed semantics — the seed is never written
+    /// ``NookPreferenceDefaults`` for the seed semantics - the seed is never written
     /// here, so a persisted user choice always wins.
     public init(preferenceDefaults: NookPreferenceDefaults) {
         appearancePreferences = NookAppearanceStore.load(default: preferenceDefaults.appearance)
@@ -170,7 +170,7 @@ public final class AppState: ObservableObject {
 
     /// Replaces ``appearancePreferences`` and writes the new value to `UserDefaults`. A
     /// no-op when the value is unchanged. Prefer this over assigning the property
-    /// directly — direct assignment skips persistence.
+    /// directly - direct assignment skips persistence.
     public func replaceAppearancePreferences(_ preferences: NookAppearancePreferences) {
         guard preferences != appearancePreferences else {
             return

--- a/Sources/NookKit/App/ModuleHost.swift
+++ b/Sources/NookKit/App/ModuleHost.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// single observable seam that makes that possible: the surface's expanded and compact
 /// content are *router views* observing this object, so re-publishing
 /// ``configuration`` re-renders the surface with the new module's content, theme, and
-/// chrome — without rebuilding the `Nook` or its window.
+/// chrome - without rebuilding the `Nook` or its window.
 ///
 /// In a single-module host the active module never changes; the object still exists so
 /// the coordinator has a uniform path to the active configuration and context.
@@ -27,7 +27,7 @@ public final class ModuleHost: ObservableObject {
     /// The id of the module whose content currently fills the surface.
     @Published public private(set) var activeModuleID: String
 
-    /// The active module's surface configuration — home/compact content, theme, chrome
+    /// The active module's surface configuration - home/compact content, theme, chrome
     /// opt-outs, lifecycle hooks. Re-publishing this is what a module switch *is*; the
     /// router views observe it.
     @Published public private(set) var configuration: NookConfiguration
@@ -39,7 +39,7 @@ public final class ModuleHost: ObservableObject {
         self.configuration = registry.module(for: id)?.makeConfiguration() ?? NookConfiguration()
     }
 
-    /// Single-module convenience — wraps one ``NookConfiguration`` as a lone module so
+    /// Single-module convenience - wraps one ``NookConfiguration`` as a lone module so
     /// the existing `NookApp.main(_:)` entry points stay a special case of the host.
     public convenience init(configuration: NookConfiguration) {
         var host = NookHostConfiguration()
@@ -66,12 +66,12 @@ public final class ModuleHost: ObservableObject {
     /// The active module's isolated context.
     public var activeContext: NookModuleContext? { registry.context(for: activeModuleID) }
 
-    /// The active module's service bag — what the surface binds to `\.appServices`.
+    /// The active module's service bag - what the surface binds to `\.appServices`.
     /// Falls back to an empty bag in the impossible case that no context can be resolved
     /// (the active module is always registered, so in practice this branch is unreachable).
     public var activeServices: AppServices { activeContext?.services ?? AppServices() }
 
-    /// `true` when more than one module is registered — i.e. a switcher is meaningful.
+    /// `true` when more than one module is registered - i.e. a switcher is meaningful.
     public var isMultiModule: Bool { registry.descriptors.count > 1 }
 
     /// Optional global shortcut that cycles modules, as configured by the host.
@@ -81,8 +81,8 @@ public final class ModuleHost: ObservableObject {
     /// the show/hide hotkey label, the menu-bar fallback). See ``NookHostBranding``.
     public var branding: NookHostBranding { registry.branding }
 
-    /// Process-global chrome behavior — hover side-effects, the cold-launch shimmer, and
-    /// the appearance→backdrop mapping. See ``NookChromeBehavior``.
+    /// Process-global chrome behavior - hover side-effects, the cold-launch shimmer, and
+    /// the appearance->backdrop mapping. See ``NookChromeBehavior``.
     public var chromeBehavior: NookChromeBehavior { registry.chromeBehavior }
 
     /// Whether the framework installs its menu-bar status item. See
@@ -93,12 +93,12 @@ public final class ModuleHost: ObservableObject {
     /// ``NookHostConfiguration/moduleSwitcherPlacement``.
     public var switcherPlacement: NookModuleSwitcherPlacement { registry.switcherPlacement }
 
-    /// Modules that want the user's attention while in the background — the switcher
+    /// Modules that want the user's attention while in the background - the switcher
     /// badges these. A backgrounded module (or a component running on its behalf) calls
     /// ``requestAttention(for:)``; switching to a module clears its badge.
     @Published public private(set) var attentionModuleIDs: Set<String> = []
 
-    /// Flags `moduleID` as wanting attention. Ignored for the foreground module — it is
+    /// Flags `moduleID` as wanting attention. Ignored for the foreground module - it is
     /// already on screen, so there is nothing to badge.
     public func requestAttention(for moduleID: String) {
         guard moduleID != activeModuleID else { return }
@@ -114,9 +114,9 @@ public final class ModuleHost: ObservableObject {
     /// re-configures the incoming one, and unloads the outgoing module when its
     /// ``NookModuleDescriptor/backgroundPolicy`` is `.unloadOnSwitchAway`.
     ///
-    /// This is pure module bookkeeping. The surface-side effects of a switch — re-wiring
+    /// This is pure module bookkeeping. The surface-side effects of a switch - re-wiring
     /// the `Nook`'s lifecycle hooks, the once-per-module `onReady`, the synthetic
-    /// `onExpand` — are ``AppCoordinator``'s, driven off the `$configuration` re-publish.
+    /// `onExpand` - are ``AppCoordinator``'s, driven off the `$configuration` re-publish.
     ///
     /// Returns `false` without changing anything when `id` is unregistered or already
     /// the active module.

--- a/Sources/NookKit/App/Modules/NookHostBranding.swift
+++ b/Sources/NookKit/App/Modules/NookHostBranding.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// A host brand mark — builds the mark view at a requested size and color. The framework
+/// A host brand mark - builds the mark view at a requested size and color. The framework
 /// renders it in the top-bar leading cluster (when no `leadingIcon` is set), the About
 /// card, and (as a template image) the menu-bar status item.
 ///
@@ -18,7 +18,7 @@ public typealias NookBrandMark = @Sendable @MainActor (_ size: CGFloat, _ color:
 /// Host-level identity surfaced through the framework chrome.
 ///
 /// Strings here name the *host product* (the `.app` the user installed), not any
-/// individual module — they are how the chrome labels itself across the multi-module
+/// individual module - they are how the chrome labels itself across the multi-module
 /// host's shared surface. The About card reads ``hostName`` and ``hostTagline``; the
 /// show/hide hotkey label and the menu-bar fallback read ``hostName``; the brand ``mark``
 /// replaces the OpenNook glyph across the chrome.
@@ -36,9 +36,9 @@ public struct NookHostBranding: Sendable, Equatable {
     public var hostTagline: String?
 
     /// Replaces the OpenNook ``NookMark`` glyph wherever the chrome renders the brand
-    /// mark — the top-bar leading cluster (when ``NookTopBarConfiguration/leadingIcon`` is
+    /// mark - the top-bar leading cluster (when ``NookTopBarConfiguration/leadingIcon`` is
     /// `nil`), the About card, and the menu-bar status icon. `nil` (the default) keeps the
-    /// OpenNook mark. Not part of ``Equatable`` (a closure can't be compared) — two
+    /// OpenNook mark. Not part of ``Equatable`` (a closure can't be compared) - two
     /// brandings are equal when their strings match.
     public var mark: NookBrandMark?
 
@@ -55,10 +55,10 @@ public struct NookHostBranding: Sendable, Equatable {
     }
 
     /// The single-module / unconfigured-host default. Reproduces the demo's strings
-    /// exactly so `NookApp.main { … }` is unchanged.
+    /// exactly so `NookApp.main { ... }` is unchanged.
     public static let `default` = NookHostBranding()
 
-    /// Builds the brand mark view at the given size/color — the host's ``mark`` if set,
+    /// Builds the brand mark view at the given size/color - the host's ``mark`` if set,
     /// otherwise the framework ``NookMarkView`` at the supplied `strokeWidth`.
     @MainActor
     public func markView(size: CGFloat, strokeWidth: CGFloat, color: Color) -> AnyView {
@@ -73,7 +73,7 @@ public struct NookHostBranding: Sendable, Equatable {
 import AppKit
 
 public extension NookHostBranding {
-    /// Renders the brand mark into a template `NSImage` for the menu-bar status item —
+    /// Renders the brand mark into a template `NSImage` for the menu-bar status item - 
     /// the host's ``mark`` if set, otherwise the framework mark.
     @MainActor
     func menuBarTemplateImage(size: CGFloat = 14) -> NSImage? {

--- a/Sources/NookKit/App/Modules/NookHostConfiguration.swift
+++ b/Sources/NookKit/App/Modules/NookHostConfiguration.swift
@@ -24,33 +24,33 @@ import Foundation
 /// `Sendable`: the registry entries hold only `Sendable` data (descriptors and
 /// `@Sendable` factory closures). A host configuration is assembled at the nonisolated
 /// top level of a `main.swift` and then handed to `NookApp.main`, which runs setup on
-/// the main actor — a real isolation crossing, so the conformance must be genuine.
+/// the main actor - a real isolation crossing, so the conformance must be genuine.
 public struct NookHostConfiguration: Sendable {
     private var entries: [NookModuleRegistry.Registration] = []
     private var explicitDefault: String?
 
-    /// Optional global shortcut that cycles to the next registered module. `nil` — the
-    /// default — means cycling is reachable only through the switcher.
+    /// Optional global shortcut that cycles to the next registered module. `nil` - the
+    /// default - means cycling is reachable only through the switcher.
     public var moduleCycleHotkey: NookHotkey?
 
-    /// Host-product identity surfaced through the framework chrome — the About card,
+    /// Host-product identity surfaced through the framework chrome - the About card,
     /// the show/hide hotkey label, the menu-bar fallback. Defaults to ``NookHostBranding/default``
     /// (`"Nook"` / nil) so an unconfigured host renders the demo strings.
     public var branding: NookHostBranding = .default
 
     /// Launch *seed* values for the process-global preferences (appearance, global
-    /// hotkey, display target). Applied at ``AppState`` construction — before first
-    /// paint and before hotkey registration — so a host ships its own out-of-box look
+    /// hotkey, display target). Applied at ``AppState`` construction - before first
+    /// paint and before hotkey registration - so a host ships its own out-of-box look
     /// and shortcut. Defaults to ``NookPreferenceDefaults/default`` (today's framework
     /// behavior). See ``NookPreferenceDefaults`` for the seed-vs-persisted semantics.
     public var preferenceDefaults: NookPreferenceDefaults = .default
 
-    /// Process-global chrome behavior — hover side-effects, the cold-launch shimmer, and
-    /// the appearance→backdrop mapping. Defaults to ``NookChromeBehavior/default``
+    /// Process-global chrome behavior - hover side-effects, the cold-launch shimmer, and
+    /// the appearance->backdrop mapping. Defaults to ``NookChromeBehavior/default``
     /// (today's framework behavior). See ``NookChromeBehavior``.
     public var chromeBehavior: NookChromeBehavior = .default
 
-    /// Whether the framework installs its menu-bar status item ("Show …" / Settings /
+    /// Whether the framework installs its menu-bar status item ("Show ..." / Settings /
     /// Quit). Defaults to `true`. Set to `false` for a host with its own menu-bar
     /// presence or none.
     public var showsMenuBarExtra: Bool = true
@@ -69,16 +69,16 @@ public struct NookHostConfiguration: Sendable {
     public init() {}
 
     /// Registers a module by descriptor and factory. The factory receives the module's
-    /// isolated ``NookModuleContext`` and is run lazily — only when the module is first
+    /// isolated ``NookModuleContext`` and is run lazily - only when the module is first
     /// activated, not at registration time.
     ///
     /// Traps on a duplicate `descriptor.id`. A module id keys persistence (the
     /// `UserDefaults` suite `"opennook.module.<id>"` and the per-module container
     /// folder), the switcher entry, the arbiter's per-module claim invalidation, and
     /// the direct-jump hotkey registration. Two registrations under the same id would
-    /// collide on every one of those silently — the second factory becomes dead code,
+    /// collide on every one of those silently - the second factory becomes dead code,
     /// the persistence suites alias, and the switcher renders two indistinguishable
-    /// entries — so we fail fast at the setup site (a `main.swift` programming bug)
+    /// entries - so we fail fast at the setup site (a `main.swift` programming bug)
     /// rather than ship the corruption into production.
     public mutating func register(
         _ descriptor: NookModuleDescriptor,
@@ -95,7 +95,7 @@ public struct NookHostConfiguration: Sendable {
     }
 
     /// Registers a module that is just a ``NookConfiguration`` with no extra product
-    /// state — the configuration is wrapped in a ``ClosureModule``.
+    /// state - the configuration is wrapped in a ``ClosureModule``.
     ///
     /// Inherits the duplicate-id `precondition` from the factory overload it delegates
     /// to.
@@ -124,7 +124,7 @@ public struct NookHostConfiguration: Sendable {
     /// Traps on an empty configuration: `NookHostConfiguration` is the multi-module
     /// entry point and is meaningless with zero registrations. An empty registry's
     /// `activeModuleID` resolves to `""`, which the arbiter treats as "background
-    /// module" for every claim — denying everything that isn't `.urgent`. That is a
+    /// module" for every claim - denying everything that isn't `.urgent`. That is a
     /// silent bug; failing fast at registration time surfaces it. Single-module hosts
     /// should use ``NookConfiguration`` directly, not `NookHostConfiguration`.
     @MainActor

--- a/Sources/NookKit/App/Modules/NookModule.swift
+++ b/Sources/NookKit/App/Modules/NookModule.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// A module owns its home view, compact slots, theme, lifecycle hooks (all expressed
 /// through the ``NookConfiguration`` it produces) and its product state and services
-/// (held as stored properties — the module instance *is* its own dependency container).
+/// (held as stored properties - the module instance *is* its own dependency container).
 ///
 /// A module is built by its factory with an isolated ``NookModuleContext``; conventionally
 /// it captures the context and persists through `context.defaults` / `context.containerURL`.
@@ -24,7 +24,7 @@ public protocol NookModule: AnyObject {
     /// registered with.
     var descriptor: NookModuleDescriptor { get }
 
-    /// Builds the surface configuration — home/compact content, theme, chrome opt-outs,
+    /// Builds the surface configuration - home/compact content, theme, chrome opt-outs,
     /// lifecycle hooks. Called when the module becomes active; the result is cached by
     /// the host until the next activation.
     func makeConfiguration() -> NookConfiguration
@@ -40,7 +40,7 @@ public protocol NookModule: AnyObject {
 
     /// Called when switching away, BEFORE ``onDeactivate()`` and any
     /// ``NookModuleDescriptor/backgroundPolicy``-driven teardown. Returns once the
-    /// module has stopped all surface activity — drained any in-flight transient
+    /// module has stopped all surface activity - drained any in-flight transient
     /// presentation and released any surface claim it holds.
     ///
     /// This is the async quiesce seam: ``onDeactivate()`` stays synchronous and is for

--- a/Sources/NookKit/App/Modules/NookModuleContext.swift
+++ b/Sources/NookKit/App/Modules/NookModuleContext.swift
@@ -19,16 +19,16 @@ public final class NookModuleContext {
     /// The module's registration-time identity.
     public let descriptor: NookModuleDescriptor
 
-    /// Per-module `UserDefaults` suite (`"opennook.module.<id>"`). Component stores —
+    /// Per-module `UserDefaults` suite (`"opennook.module.<id>"`). Component stores - 
     /// e.g. `NookComponents`' `ShelfStore`, which already accepts an injected
-    /// `defaults:` — should be wired to this so their keys can't collide across modules.
+    /// `defaults:` - should be wired to this so their keys can't collide across modules.
     public let defaults: UserDefaults
 
     /// Per-module service bag, injected into the module's views via `\.appServices`.
     public let services: AppServices
 
     /// Suggested on-disk container for module-owned files (databases, caches):
-    /// `Application Support/<host>/Modules/<id>/`. Not created on disk — the module
+    /// `Application Support/<host>/Modules/<id>/`. Not created on disk - the module
     /// creates it on first use.
     public let containerURL: URL
 

--- a/Sources/NookKit/App/Modules/NookModuleDescriptor.swift
+++ b/Sources/NookKit/App/Modules/NookModuleDescriptor.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// The cheap, registration-time identity of a notch module — everything the host and
+/// The cheap, registration-time identity of a notch module - everything the host and
 /// the module switcher need *before* the module itself is instantiated.
 ///
 /// A ``NookModule`` carries product state and views; a descriptor carries only the
@@ -19,7 +19,7 @@ import SwiftUI
 /// handed to the main actor as part of a ``NookHostConfiguration``, so it genuinely
 /// crosses an isolation boundary and the conformance must be real.
 public struct NookModuleDescriptor: Identifiable, Sendable {
-    /// Stable, unique identifier — reverse-DNS by convention (`"com.you.nuggie"`).
+    /// Stable, unique identifier - reverse-DNS by convention (`"com.you.nuggie"`).
     /// Used as the switcher key, the per-module `UserDefaults` suite name, and the
     /// on-disk container folder name, so it must not change across releases.
     public let id: String
@@ -29,13 +29,13 @@ public struct NookModuleDescriptor: Identifiable, Sendable {
 
     /// SF Symbol shown for this module in the module switcher. (The top-bar leading
     /// cluster is driven separately by ``NookTopBarConfiguration/leadingIcon`` and the
-    /// host brand mark — not by this descriptor.)
+    /// host brand mark - not by this descriptor.)
     public var icon: String
 
     /// Accent used to tint the module's switcher entry.
     public var accent: Color
 
-    /// Optional global hotkey that jumps straight to this module. `nil` — the default —
+    /// Optional global hotkey that jumps straight to this module. `nil` - the default - 
     /// means the module is reachable only via the switcher or the cycle hotkey.
     public var hotkey: NookHotkey?
 
@@ -49,7 +49,7 @@ public struct NookModuleDescriptor: Identifiable, Sendable {
         case unloadOnSwitchAway
 
         /// Keep the module instance alive in the background so its services and
-        /// activity queue keep running. It can still post activities — the
+        /// activity queue keep running. It can still post activities - the
         /// `SurfaceArbiter` gates whether a background module reaches the surface.
         case stayResident
     }

--- a/Sources/NookKit/App/Modules/NookModuleRegistry.swift
+++ b/Sources/NookKit/App/Modules/NookModuleRegistry.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// Registration is cheap (descriptors + factories); construction is deferred until a
 /// module is first activated. A constructed module is cached with its
-/// ``NookModuleContext`` until ``unload(_:)`` drops it — which the host does for a
+/// ``NookModuleContext`` until ``unload(_:)`` drops it - which the host does for a
 /// module whose ``NookModuleDescriptor/backgroundPolicy`` is `.unloadOnSwitchAway`.
 @MainActor
 public final class NookModuleRegistry {
@@ -29,7 +29,7 @@ public final class NookModuleRegistry {
 
     private let registrations: [Registration]
 
-    /// The module shown at launch — the host's explicit choice, else the first registered.
+    /// The module shown at launch - the host's explicit choice, else the first registered.
     public let defaultModuleID: String
 
     /// Optional global shortcut that cycles to the next module. `nil` when the host did
@@ -43,7 +43,7 @@ public final class NookModuleRegistry {
     public let branding: NookHostBranding
 
     /// Process-global chrome behavior (hover side-effects, cold-launch shimmer,
-    /// appearance→backdrop mapping). Held here for the same reason as ``branding`` — so
+    /// appearance->backdrop mapping). Held here for the same reason as ``branding`` - so
     /// ``ModuleHost`` and ``AppCoordinator`` can read it without a reference back to the
     /// host configuration. See ``NookChromeBehavior``.
     public let chromeBehavior: NookChromeBehavior
@@ -59,11 +59,11 @@ public final class NookModuleRegistry {
 
     /// One broker per host process, shared across every module. Registered into each
     /// module's ``AppServices`` as ``NookModuleContext`` is built, so a view in module A
-    /// and a view in module B both resolve the same instance — pins compose into one
+    /// and a view in module B both resolve the same instance - pins compose into one
     /// aggregate signal the coordinator can fold into ``AppCoordinator/isUserEngaged``.
     public let presentationPinning: NookPresentationPinning
 
-    /// One file picker per host process, shared across every module — same lifetime and
+    /// One file picker per host process, shared across every module - same lifetime and
     /// rationale as ``presentationPinning`` (it depends on that broker to hold the
     /// surface while a panel is up). Registered into each module's ``AppServices`` as
     /// ``NookModuleContext`` is built. See ``NookFilePicker``.
@@ -93,7 +93,7 @@ public final class NookModuleRegistry {
         self.filePicker = NookFilePicker(presentationPinning: presentationPinning)
     }
 
-    /// All registered modules' descriptors, in registration order — the switcher's list.
+    /// All registered modules' descriptors, in registration order - the switcher's list.
     public var descriptors: [NookModuleDescriptor] {
         registrations.map(\.descriptor)
     }

--- a/Sources/NookKit/App/NookAppearancePreferences.swift
+++ b/Sources/NookKit/App/NookAppearancePreferences.swift
@@ -9,7 +9,7 @@ import Foundation
 import NookSurface
 import SwiftUI
 
-/// Persistent personalization for the Nook chrome — appearance (materials, palette),
+/// Persistent personalization for the Nook chrome - appearance (materials, palette),
 /// layout, and chrome behavior that should survive across launches.
 public struct NookAppearancePreferences: Equatable, Codable, Sendable {
     /// Follow the macOS appearance, or pin the chrome to dark / light.
@@ -18,12 +18,12 @@ public struct NookAppearancePreferences: Equatable, Codable, Sendable {
     /// Solid (opaque, matches the notch) or translucent (frosted, shows the wallpaper).
     public var surfaceStyle: NookSurfaceStyle
 
-    /// Notch-fused or free-floating chrome — `.auto` follows the display. See
+    /// Notch-fused or free-floating chrome - `.auto` follows the display. See
     /// ``NookPresentation``. This is what lets OpenNook work on a Mac with no notch.
     public var presentation: NookPresentation
 
     /// When on, completion-style events play a one-shot trackpad haptic via
-    /// `NSHapticFeedbackManager`. Off by default — macOS haptics only fire when the user's
+    /// `NSHapticFeedbackManager`. Off by default - macOS haptics only fire when the user's
     /// hand is on a Force Touch trackpad with system haptics enabled, so this is a bonus
     /// completion signal, never the primary feedback channel.
     public var hapticFeedbackEnabled: Bool
@@ -58,7 +58,7 @@ public struct NookAppearancePreferences: Equatable, Codable, Sendable {
         self.backdropStrength = backdropStrength
     }
 
-    /// Framework defaults — what `NookApp.main()` ships if the host has never written
+    /// Framework defaults - what `NookApp.main()` ships if the host has never written
     /// preferences.
     public static let `default` = NookAppearancePreferences()
 
@@ -99,7 +99,7 @@ public struct NookAppearancePreferences: Equatable, Codable, Sendable {
     }
 }
 
-/// Pins the chrome palette to follow macOS or to a fixed light/dark — independent of
+/// Pins the chrome palette to follow macOS or to a fixed light/dark - independent of
 /// the wallpaper-aware ``NookSurfaceStyle``.
 public enum NookChromePalette: String, Codable, Sendable, CaseIterable {
     case followSystem
@@ -107,8 +107,8 @@ public enum NookChromePalette: String, Codable, Sendable, CaseIterable {
     case light
 }
 
-/// `.solid` paints the chrome the same opaque color as the menu-bar notch — true black on
-/// dark, true white on light — so the expanded panel reads as one continuous surface.
+/// `.solid` paints the chrome the same opaque color as the menu-bar notch - true black on
+/// dark, true white on light - so the expanded panel reads as one continuous surface.
 /// `.translucent` shows the wallpaper through a frosted material instead. `.liquidGlass`
 /// renders Apple's Liquid Glass material (macOS 26+), with a layered approximation on
 /// earlier systems; Reduce Transparency collapses both translucent styles to `.solid`.

--- a/Sources/NookKit/App/NookBackdropMapping.swift
+++ b/Sources/NookKit/App/NookBackdropMapping.swift
@@ -13,7 +13,7 @@ import SwiftUI
 ///
 /// Three outcomes: a solid opaque fill (the `.solid` surface style, or any time Reduce
 /// Transparency is on), a frosted vibrancy material with a slight darken pass on top, or
-/// a Liquid Glass material — each with a darken pass scaled by `backdropStrength`.
+/// a Liquid Glass material - each with a darken pass scaled by `backdropStrength`.
 public enum NookBackdropMapping {
     public static func notchBackdrop(
         preferences: NookAppearancePreferences,
@@ -29,7 +29,7 @@ public enum NookBackdropMapping {
         // `.solid` and Reduce Transparency both want the same answer: a real opaque
         // color, no visual-effect view. Pure black / white so the chrome reads as the
         // same surface as the physical notch. RT also collapses the translucent styles
-        // here — neither glass nor frost should render when the user opted out.
+        // here - neither glass nor frost should render when the user opted out.
         if preferences.surfaceStyle == .solid || reduceTransparency {
             return .solid(isDark ? .black : .white)
         }
@@ -47,7 +47,7 @@ public enum NookBackdropMapping {
                 darkenOpacity: baseDarken * strength
             ))
         case .liquidGlass:
-            // Neutral glass (no tint) — the real material refracts the wallpaper itself.
+            // Neutral glass (no tint) - the real material refracts the wallpaper itself.
             // A lighter darken than frost since glass keeps its own contrast; a bright
             // rim sells the edge on the pre-Tahoe approximation. The default shading runs
             // top-to-bottom and tapers to 40% at the bottom, so the surface reads glassier
@@ -63,7 +63,7 @@ public enum NookBackdropMapping {
                 ]))
             ))
         case .solid:
-            // Unreachable — handled by the guard above. Kept so the switch stays
+            // Unreachable - handled by the guard above. Kept so the switch stays
             // exhaustive without a `default` that would swallow a future style.
             return .solid(isDark ? .black : .white)
         }

--- a/Sources/NookKit/App/NookChromeBehavior.swift
+++ b/Sources/NookKit/App/NookChromeBehavior.swift
@@ -12,14 +12,14 @@ import SwiftUI
 /// hover side-effects, the cold-launch greeting, and how appearance preferences map to
 /// the surface backdrop.
 ///
-/// These are distinct from ``NookConfiguration``'s per-surface content/theme seams —
+/// These are distinct from ``NookConfiguration``'s per-surface content/theme seams - 
 /// they describe how the single shared notch surface *behaves*, so they live at the
 /// host-process level (``NookHostConfiguration/chromeBehavior``). The single-module path
 /// mirrors them on ``NookConfiguration/chromeBehavior`` and forwards onto the synthesized
 /// host. The default value reproduces today's framework behavior exactly.
 ///
 /// `Sendable`: assembled at a `main.swift`'s nonisolated top level and handed to
-/// `NookApp.main`, which crosses to the main actor — like the configurations that carry
+/// `NookApp.main`, which crosses to the main actor - like the configurations that carry
 /// it. Not `Equatable` because ``backdrop`` carries a closure.
 public struct NookChromeBehavior: Sendable {
     /// Resolves the surface backdrop from the live appearance state. Returns the
@@ -34,13 +34,13 @@ public struct NookChromeBehavior: Sendable {
         @Sendable @MainActor (NookAppearancePreferences, ColorScheme, Bool) -> NookBackdrop
 
     /// Side-effects to apply while the cursor is over the chrome. Defaults to `[]` (the
-    /// framework default — neither hover-keep-visible nor hover haptics). Set to
+    /// framework default - neither hover-keep-visible nor hover haptics). Set to
     /// ``NookHoverBehavior/all`` (or a subset) to opt in. Read once when the surface is
     /// built, like ``NookConfiguration/style``.
     public var hoverBehavior: NookHoverBehavior
 
     /// Whether the one-shot perimeter shimmer plays at cold launch. Defaults to `true`
-    /// (today's greeting). Set to `false` for a silent launch — the chrome still settles
+    /// (today's greeting). Set to `false` for a silent launch - the chrome still settles
     /// into its compact launch state, it just skips the feedback flourish.
     public var showsLaunchShimmer: Bool
 
@@ -61,7 +61,7 @@ public struct NookChromeBehavior: Sendable {
         self.backdrop = backdrop
     }
 
-    /// The framework defaults — what ships when a host sets no chrome behavior. Using
+    /// The framework defaults - what ships when a host sets no chrome behavior. Using
     /// this reproduces today's behavior exactly.
     public static let `default` = NookChromeBehavior()
 }

--- a/Sources/NookKit/App/NookChromeLabels.swift
+++ b/Sources/NookKit/App/NookChromeLabels.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// Host-overridable strings the framework chrome renders — for localization or product
+/// Host-overridable strings the framework chrome renders - for localization or product
 /// naming (e.g. "Preferences" instead of "Settings"). Defaults reproduce today's English.
 ///
 /// Set via ``NookConfiguration/labels``. The values reach the top bar and the status

--- a/Sources/NookKit/App/NookChromeMetrics.swift
+++ b/Sources/NookKit/App/NookChromeMetrics.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// Host-tunable layout metrics for the framework chrome — the few fixed point values
+/// Host-tunable layout metrics for the framework chrome - the few fixed point values
 /// that were previously baked into the views as `NookLayout` constants. Defaults
 /// reproduce today's layout exactly.
 ///
@@ -22,14 +22,14 @@ public struct NookChromeMetrics: Sendable, Equatable {
     /// ``NookConfiguration/expandedWidth``. Distinct from
     /// ``NookStyle/expandedContentInsets`` (the chrome's own `.safeAreaInset` strip on
     /// ``NookView``). Host home views should not mirror this with extra horizontal
-    /// padding — read ``EnvironmentValues/nookContentInsets`` instead. See
+    /// padding - read ``EnvironmentValues/nookContentInsets`` instead. See
     /// `Examples/LayoutNook/main.swift`.
     public var edgePadding: CGFloat
 
     /// Square size of each compact pill slot (the glyphs flanking the notch). Default `24`.
     public var compactSlotSize: CGFloat
 
-    /// Maximum width of the top bar's module-breadcrumb label before it fades — capped to
+    /// Maximum width of the top bar's module-breadcrumb label before it fades - capped to
     /// the leading pre-notch region so it doesn't split across the notch. Default `140`.
     public var breadcrumbMaxWidth: CGFloat
 
@@ -48,7 +48,7 @@ public struct NookChromeMetrics: Sendable, Equatable {
         self.topBarHeight = topBarHeight
     }
 
-    /// The framework-default metrics — reproduces today's layout.
+    /// The framework-default metrics - reproduces today's layout.
     public static let `default` = NookChromeMetrics()
 }
 

--- a/Sources/NookKit/App/NookChromeMotion.swift
+++ b/Sources/NookKit/App/NookChromeMotion.swift
@@ -7,18 +7,18 @@
 
 import SwiftUI
 
-/// Host-tunable animation curves for the chrome's *in-panel* motion — the transitions
+/// Host-tunable animation curves for the chrome's *in-panel* motion - the transitions
 /// inside the expanded surface and top bar. Defaults reproduce today's springs exactly.
 ///
 /// This is distinct from ``NookConfiguration/transitions`` (``NookTransitionConfiguration``),
 /// which governs the surface-level expand / collapse / compact conversion. These curves
-/// drive the home↔settings swap, the status banner, the breadcrumb, and the leading
+/// drive the home<->settings swap, the status banner, the breadcrumb, and the leading
 /// cluster's back / hover reveals.
 ///
 /// Set via ``NookConfiguration/motion``. The values reach the views through the chrome
 /// environment (``EnvironmentValues/nookChromeMotion``).
 public struct NookChromeMotion: Sendable, Equatable {
-    /// Home↔Settings swap and the gear toggle (and the matching `viewMode` animations).
+    /// Home<->Settings swap and the gear toggle (and the matching `viewMode` animations).
     public var viewModeChange: Animation
 
     /// The leading cluster's back-control activation (exiting Settings / clearing a
@@ -48,7 +48,7 @@ public struct NookChromeMotion: Sendable, Equatable {
         self.breadcrumb = breadcrumb
     }
 
-    /// The framework-default springs — reproduces today's in-panel motion.
+    /// The framework-default springs - reproduces today's in-panel motion.
     public static let `default` = NookChromeMotion()
 }
 

--- a/Sources/NookKit/App/NookConfiguration.swift
+++ b/Sources/NookKit/App/NookConfiguration.swift
@@ -8,7 +8,7 @@
 import NookSurface
 import SwiftUI
 
-/// The host-app registration seam — everything a notch app customizes without forking
+/// The host-app registration seam - everything a notch app customizes without forking
 /// the framework.
 ///
 /// Pass one to `NookApp.main(_:)`. The default value reproduces the demo exactly, so
@@ -30,7 +30,7 @@ import SwiftUI
 /// ```
 ///
 /// > Note: This is a *registration* entry point, distinct from the `NookSurface`-level
-/// > customization types (`NookStyle`, `NookHoverBehavior`, …). It exists so a host can
+/// > customization types (`NookStyle`, `NookHoverBehavior`, ...). It exists so a host can
 /// > depend on the package and customize through public API only.
 public struct NookConfiguration: Sendable {
     /// The expanded home surface, shown between the framework top bar and Settings.
@@ -39,7 +39,7 @@ public struct NookConfiguration: Sendable {
     /// `@MainActor`: these content/theme closures build SwiftUI views and resolve the
     /// chrome palette, which only ever happens during main-actor view rendering.
     /// `@Sendable`: a `NookConfiguration` is assembled at launch and handed to the
-    /// main-actor coordinator, so the whole value is `Sendable` — every closure it
+    /// main-actor coordinator, so the whole value is `Sendable` - every closure it
     /// carries crosses that boundary and must be too.
     public var home: @Sendable @MainActor () -> AnyView
 
@@ -61,7 +61,7 @@ public struct NookConfiguration: Sendable {
     /// the built-in screen; the host view reads ``AppState`` via `@EnvironmentObject`.
     public var settings: (@Sendable @MainActor () -> AnyView)? = nil
 
-    /// Top-bar configuration — leading cluster (title/icon), and the two visibility
+    /// Top-bar configuration - leading cluster (title/icon), and the two visibility
     /// flags for the top bar and the Settings UI. Grouped so the related knobs
     /// travel together and future top-bar settings land here cleanly. See
     /// ``NookTopBarConfiguration``.
@@ -76,8 +76,8 @@ public struct NookConfiguration: Sendable {
     /// seed-vs-persisted semantics.
     public var preferenceDefaults: NookPreferenceDefaults = .default
 
-    /// Process-global chrome behavior — hover side-effects, the cold-launch shimmer, and
-    /// the appearance→backdrop mapping. On the single-module path this is forwarded onto
+    /// Process-global chrome behavior - hover side-effects, the cold-launch shimmer, and
+    /// the appearance->backdrop mapping. On the single-module path this is forwarded onto
     /// the synthesized ``NookHostConfiguration/chromeBehavior``; multi-module hosts set it
     /// on ``NookHostConfiguration`` directly. Defaults to ``NookChromeBehavior/default``
     /// (today's framework behavior). See ``NookChromeBehavior``.
@@ -93,31 +93,31 @@ public struct NookConfiguration: Sendable {
     /// See ``NookChromeMetrics``.
     public var metrics: NookChromeMetrics = .default
 
-    /// Host-tunable in-panel motion curves (home↔settings, banner, breadcrumb, leading
+    /// Host-tunable in-panel motion curves (home<->settings, banner, breadcrumb, leading
     /// cluster). Distinct from ``transitions`` (surface-level expand/collapse). Defaults
     /// to ``NookChromeMotion/default`` (today's springs). See ``NookChromeMotion``.
     public var motion: NookChromeMotion = .default
 
-    /// Host-product identity surfaced through the chrome — name, tagline, and brand mark
+    /// Host-product identity surfaced through the chrome - name, tagline, and brand mark
     /// (About card, show/hide hotkey label, menu-bar fallback, top-bar leading mark). On
     /// the single-module path this is forwarded onto the synthesized
     /// ``NookHostConfiguration/branding``; multi-module hosts set it on
     /// ``NookHostConfiguration`` directly. Defaults to ``NookHostBranding/default``.
     public var branding: NookHostBranding = .default
 
-    /// Whether the framework installs its menu-bar status item (the "Show …" / Settings /
+    /// Whether the framework installs its menu-bar status item (the "Show ..." / Settings /
     /// Quit fallback). Defaults to `true`. Set to `false` for a host that owns its own
     /// menu-bar presence or wants none. On the single-module path this is forwarded onto
     /// ``NookHostConfiguration/showsMenuBarExtra``.
     public var showsMenuBarExtra: Bool = true
 
-    /// Overrides the chrome's corner radii — the small rounding into the notch arch and
+    /// Overrides the chrome's corner radii - the small rounding into the notch arch and
     /// the larger rounding where the panel meets the wallpaper. `nil` (the default) uses
     /// the framework's radii, tuned to sit well under the menu bar on notched MacBooks.
     /// See ``NookStyle``.
     public var style: NookStyle? = nil
 
-    /// Overrides the expand / collapse / compact↔expanded animation curves. `nil` (the
+    /// Overrides the expand / collapse / compact<->expanded animation curves. `nil` (the
     /// default) uses the framework's soft springs. Supply a ``NookTransitionConfiguration``
     /// to retune or to slow the chrome down (set its `animationDuration` so awaited
     /// `expand()`/`compact()` still return once the chrome has visibly arrived).
@@ -136,8 +136,8 @@ public struct NookConfiguration: Sendable {
     ///
     /// Bottom command rows that should span the full content column should use
     /// `frame(maxWidth: .infinity, alignment: .leading)` on the row, then pad by
-    /// `nookContentInsets` on the sides and bottom — not shrink-wrap to their buttons
-    /// and not add a separate `.padding(.horizontal, …)` on the home root.
+    /// `nookContentInsets` on the sides and bottom - not shrink-wrap to their buttons
+    /// and not add a separate `.padding(.horizontal, ...)` on the home root.
     public var expandedWidth: CGFloat? = nil
 
     /// Called when the chrome transitions into the expanded surface (from any source).
@@ -154,20 +154,20 @@ public struct NookConfiguration: Sendable {
 
     /// Handles a file drop on the notch panel. Return `true` to accept the URLs
     /// (the nook stays expanded so any registration UI is visible), `false` to
-    /// reject. `nil` — the default — rejects all drops.
+    /// reject. `nil` - the default - rejects all drops.
     ///
     /// `NookComponents`' file shelf wires its `ShelfStore.accept` straight into
     /// this; a host can also route drops through its own import flow.
     public var onFileDrop: (@Sendable @MainActor ([URL]) -> Bool)?
 
-    /// Called once, on the main actor, at the end of `AppCoordinator.start()` — a
+    /// Called once, on the main actor, at the end of `AppCoordinator.start()` - a
     /// post-launch handle on the live coordinator.
     ///
     /// `NookComponents`' activity queue uses this to `bind` itself to the coordinator
     /// (which conforms to ``NookSurfacePresenting``); a host can also use it to drive
     /// the chrome or observe state after launch.
     ///
-    /// Typed `@MainActor` — it always runs on the main actor — so the callback may call
+    /// Typed `@MainActor` - it always runs on the main actor - so the callback may call
     /// main-actor-isolated API (e.g. `NookActivityQueue.bind`) directly.
     public var onReady: (@Sendable @MainActor (AppCoordinator) -> Void)?
 
@@ -188,7 +188,7 @@ public struct NookConfiguration: Sendable {
     ///
     /// The closure is `@MainActor` because it builds a SwiftUI view, and `@Sendable` so
     /// these (nonisolated) `mutating` setters can store it into the main-actor `home`
-    /// slot — which a `Sendable` `NookConfiguration` requires — without a "sending"
+    /// slot - which a `Sendable` `NookConfiguration` requires - without a "sending"
     /// violation. `Content: Sendable` lets the stored `@Sendable` wrapper close over the
     /// `Content` metatype; a SwiftUI view value is a `Sendable` value type in practice.
     public mutating func setHome<Content: View & Sendable>(
@@ -224,7 +224,7 @@ public struct NookConfiguration: Sendable {
     /// Registers host actions for the top bar's trailing cluster from a `@ViewBuilder`
     /// closure. The items render immediately left of the framework's keep-open lock and
     /// gear, themed and able to observe ``AppState``. See
-    /// ``NookTopBarConfiguration/trailingItems`` for the space/clipping guidance — keep
+    /// ``NookTopBarConfiguration/trailingItems`` for the space/clipping guidance - keep
     /// these compact glyph-style buttons.
     public mutating func setTopBarTrailingItems<Content: View & Sendable>(
         @ViewBuilder _ content: @escaping @Sendable @MainActor () -> Content
@@ -233,7 +233,7 @@ public struct NookConfiguration: Sendable {
     }
 }
 
-/// The framework top bar's host-configurable surface — the leading cluster
+/// The framework top bar's host-configurable surface - the leading cluster
 /// (title / icon), plus the two flags that strip the bar or the Settings UI for
 /// hosts that want a bare glance/widget chrome.
 ///
@@ -253,7 +253,7 @@ public struct NookTopBarConfiguration: Sendable {
 
     /// Whether the expanded surface renders the framework top bar (leading cluster,
     /// keep-open lock, gear). Defaults to `true`. Set to `false` for a bare expanded
-    /// surface — a pure glance/widget with no framework chrome.
+    /// surface - a pure glance/widget with no framework chrome.
     ///
     /// With the top bar off the gear is gone, so Settings is unreachable from the
     /// chrome regardless of ``showsSettings``; the keep-open lock is gone too (it
@@ -261,17 +261,17 @@ public struct NookTopBarConfiguration: Sendable {
     public var showsTopBar: Bool
 
     /// Whether the gear and the reachable Settings screen are part of the chrome.
-    /// Defaults to `true`. Set to `false` to drop the Settings UI entirely — the gear
-    /// is removed, the menu-bar "Settings…" item is dropped, and the expanded
+    /// Defaults to `true`. Set to `false` to drop the Settings UI entirely - the gear
+    /// is removed, the menu-bar "Settings..." item is dropped, and the expanded
     /// surface stays on the home view.
     public var showsSettings: Bool
 
     /// Whether the framework's transient status banner (driven by ``AppState/status``)
     /// renders under the top bar. Defaults to `true`. Set to `false` to suppress the
-    /// framework banner — e.g. a host surfacing status inside its own home content.
+    /// framework banner - e.g. a host surfacing status inside its own home content.
     public var showsStatusBanner: Bool
 
-    /// The label for the top bar's leading cluster. Defaults to `"Home"` — override
+    /// The label for the top bar's leading cluster. Defaults to `"Home"` - override
     /// so the bar communicates *product* context (a date, a section name) rather
     /// than the demo's navigation metaphor. The closure receives ``AppState`` for
     /// hosts whose label depends on it.
@@ -288,8 +288,8 @@ public struct NookTopBarConfiguration: Sendable {
 
     /// Host-supplied actions for the top bar's **trailing** cluster, rendered to the
     /// left of the framework's keep-open lock and gear (so the order reads
-    /// host items → lock → gear). `nil` (the default) reproduces the framework chrome
-    /// exactly — just the lock and gear. Use ``NookConfiguration/setTopBarTrailingItems(_:)``
+    /// host items -> lock -> gear). `nil` (the default) reproduces the framework chrome
+    /// exactly - just the lock and gear. Use ``NookConfiguration/setTopBarTrailingItems(_:)``
     /// to set it from a `@ViewBuilder`.
     ///
     /// The items render inside the same chrome environment as the rest of the top bar,
@@ -297,9 +297,9 @@ public struct NookTopBarConfiguration: Sendable {
     /// palette via `@Environment(\.nookResolvedTheme)`.
     ///
     /// > Important: Space is tight. The chrome's top edge sits at the menu-bar level, so
-    /// > the top bar runs *under* the physical notch on a notched display — anything
+    /// > the top bar runs *under* the physical notch on a notched display - anything
     /// > between the notch's edges is hardware-clipped. The trailing cluster lives to the
-    /// > right of the notch, leaving only ~80–100pt of usable width at the 480–520pt
+    /// > right of the notch, leaving only ~80-100pt of usable width at the 480-520pt
     /// > expanded widths. Host items should be compact glyph-style buttons (matching the
     /// > lock/gear weight), not wide labeled pills.
     ///
@@ -309,7 +309,7 @@ public struct NookTopBarConfiguration: Sendable {
     public var trailingItems: (@Sendable @MainActor () -> AnyView)?
 
     /// How the icon row spans the expanded content column. Default
-    /// ``Width/contentColumn`` — leading/trailing icons share the same horizontal
+    /// ``Width/contentColumn`` - leading/trailing icons share the same horizontal
     /// gutter as host home content. ``Width/intrinsic`` reproduces the legacy
     /// shrink-wrapped, centered bar.
     public var width: Width
@@ -332,6 +332,6 @@ public struct NookTopBarConfiguration: Sendable {
         self.width = width
     }
 
-    /// The framework-demo defaults — top bar on, Settings on, "Home" with the brand mark.
+    /// The framework-demo defaults - top bar on, Settings on, "Home" with the brand mark.
     public static let `default` = NookTopBarConfiguration()
 }

--- a/Sources/NookKit/App/NookDisplayPreference.swift
+++ b/Sources/NookKit/App/NookDisplayPreference.swift
@@ -13,11 +13,11 @@ import Foundation
 /// "which screen" is a real choice. This expresses that choice in a form that
 /// survives reboots and display reconfiguration:
 ///
-/// - ``Mode/builtIn`` — the laptop's built-in (notched) panel. The default: a notch
+/// - ``Mode/builtIn`` - the laptop's built-in (notched) panel. The default: a notch
 ///   app's chrome belongs where the physical notch is.
-/// - ``Mode/main`` — whichever display currently hosts the active menu bar
+/// - ``Mode/main`` - whichever display currently hosts the active menu bar
 ///   (`NSScreen.main`). Follows the user's focus across screens.
-/// - ``Mode/specific`` — a single named display, pinned by its stable display UUID
+/// - ``Mode/specific`` - a single named display, pinned by its stable display UUID
 ///   (``displayUUID``). Survives unplug/replug and arrangement changes.
 ///
 /// Resolving a preference to a concrete `NSScreen` is ``NookScreenLocator``'s job;

--- a/Sources/NookKit/App/NookFilePicker.swift
+++ b/Sources/NookKit/App/NookFilePicker.swift
@@ -14,14 +14,14 @@ import UniformTypeIdentifiers
 ///
 /// **Why a module shouldn't roll its own `NSOpenPanel`.** The host is an agent app
 /// (`LSUIElement`) whose only window is a `.nonactivatingPanel`. Clicking the notch
-/// never activates the app — that is the point of a non-activating panel — so at the
+/// never activates the app - that is the point of a non-activating panel - so at the
 /// moment a module asks for a file, the app is *inactive*. An `NSOpenPanel` presented
 /// by an inactive agent app comes up non-key: it may appear behind the frontmost app
 /// and its sidebar / navigation stop responding to clicks. The fix is to request app
 /// activation immediately before presenting. Every module would otherwise have to
 /// rediscover this; the host owns it once, here.
 ///
-/// **Pinning.** A picker is a separate AppKit panel outside the notch window — the same
+/// **Pinning.** A picker is a separate AppKit panel outside the notch window - the same
 /// situation ``NookPresentationPinning`` exists for. While the panel is up the pointer
 /// has left the notch, so without intervention the surface auto-compacts (taking nothing
 /// visible with it, but dropping engagement) and a competing module's arbiter claim can
@@ -157,8 +157,8 @@ public struct NookSaveOptions: Sendable {
 ///
 /// The system starts security-scoped access on panel-returned URLs implicitly. This
 /// type balances that grant: it stops access for each URL when it is released
-/// (`deinit`), so a long-running process doesn't leak the scope. Do content reads —
-/// or capture a `.withSecurityScope` bookmark to persist access across launches —
+/// (`deinit`), so a long-running process doesn't leak the scope. Do content reads - 
+/// or capture a `.withSecurityScope` bookmark to persist access across launches - 
 /// while the selection is alive, ideally inside ``withAccess(_:)``. After the selection
 /// is released the URLs are path-level only and reads will fail under the sandbox.
 public final class NookFileSelection: Sendable {
@@ -166,7 +166,7 @@ public final class NookFileSelection: Sendable {
     /// destination URL.
     public let urls: [URL]
 
-    /// The first (or only) picked URL — convenient for the save / single-file case.
+    /// The first (or only) picked URL - convenient for the save / single-file case.
     public var url: URL? { urls.first }
 
     init(urls: [URL]) {
@@ -175,8 +175,8 @@ public final class NookFileSelection: Sendable {
 
     /// Runs `body` while the selection's security-scoped access is live, returning its
     /// result. The access is already active for the selection's lifetime; this method is
-    /// the recommended bracket for reads and bookmark capture so the intent — "use the
-    /// files now, while you're allowed to" — is explicit at the call site.
+    /// the recommended bracket for reads and bookmark capture so the intent - "use the
+    /// files now, while you're allowed to" - is explicit at the call site.
     @discardableResult
     public func withAccess<T>(_ body: ([URL]) throws -> T) rethrows -> T {
         try body(urls)
@@ -287,7 +287,7 @@ public final class NookFilePicker: NookFilePresenting {
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<[URL], Never>) in
                 // If the surrounding task was already cancelled, don't even show the
-                // panel — resume empty. `begin` is never called, so there is exactly one
+                // panel - resume empty. `begin` is never called, so there is exactly one
                 // resume on this path.
                 if Task.isCancelled {
                     continuation.resume(returning: [])
@@ -300,7 +300,7 @@ public final class NookFilePicker: NookFilePresenting {
         } onCancel: {
             // Task cancelled (e.g. the presenting view went away). Dismiss the panel;
             // that routes through `begin`'s single completion with `.cancel`, which is
-            // the only place the continuation resumes — so no double-resume.
+            // the only place the continuation resumes - so no double-resume.
             Task { @MainActor [weak self] in
                 self?.activePanel?.cancel(nil)
             }

--- a/Sources/NookKit/App/NookHaptics.swift
+++ b/Sources/NookKit/App/NookHaptics.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 /// Centralized trackpad haptics for completion-style events. Reads
-/// `appearancePreferences.hapticFeedbackEnabled` at the call site — never fires when
+/// `appearancePreferences.hapticFeedbackEnabled` at the call site - never fires when
 /// the preference is off. macOS only delivers the pulse when the user's hand is on a
 /// Force Touch trackpad and "Force Click and haptic feedback" is enabled in System
 /// Settings, so a missed pulse on a mouse-driven session is expected, not a bug.

--- a/Sources/NookKit/App/NookHotkeyIDs.swift
+++ b/Sources/NookKit/App/NookHotkeyIDs.swift
@@ -11,7 +11,7 @@
 /// fallback) can match against them without a magic-string literal that drifts from
 /// the registration call site in ``AppCoordinator``.
 ///
-/// Module-defined registrations use `"module.\(id)"` and `"cycle"` — these too are
+/// Module-defined registrations use `"module.\(id)"` and `"cycle"` - these too are
 /// declared here so a host can recognise them when iterating
 /// ``AppState/hotkeyRegistrationFailures``.
 enum NookHotkeyIDs {

--- a/Sources/NookKit/App/NookPreferenceDefaults.swift
+++ b/Sources/NookKit/App/NookPreferenceDefaults.swift
@@ -13,20 +13,20 @@ import Foundation
 /// global show/hide ``NookHotkey``, and the ``NookDisplayPreference``.
 ///
 /// These are **seed** values, not overrides. They replace the framework `.default`
-/// fallback used when nothing is persisted yet — so a host can ship its own out-of-box
+/// fallback used when nothing is persisted yet - so a host can ship its own out-of-box
 /// look (e.g. dark, translucent, floating, pinned-open) and shortcut without the user
 /// having to open Settings first. The moment the user changes one of these at runtime
 /// the change is persisted and always wins; a seed value is **never written** to
 /// `UserDefaults`, so revising a default in a later build still reaches users who never
 /// touched that setting.
 ///
-/// Because there is a single ``AppState`` per process, these are host-process-global —
+/// Because there is a single ``AppState`` per process, these are host-process-global - 
 /// set them on ``NookHostConfiguration/preferenceDefaults`` (multi-module) or, for the
 /// single-module path, on ``NookConfiguration/preferenceDefaults`` (forwarded to the
 /// synthesized host). The default value reproduces the framework exactly.
 ///
 /// `Sendable`: assembled at a `main.swift`'s nonisolated top level and handed to
-/// `NookApp.main`, which crosses to the main actor — like the configurations that carry
+/// `NookApp.main`, which crosses to the main actor - like the configurations that carry
 /// it.
 public struct NookPreferenceDefaults: Sendable, Equatable {
     /// First-run appearance personalization. Defaults to ``NookAppearancePreferences/default``.
@@ -48,7 +48,7 @@ public struct NookPreferenceDefaults: Sendable, Equatable {
         self.display = display
     }
 
-    /// The framework defaults — what ships when a host sets no launch preferences. Using
+    /// The framework defaults - what ships when a host sets no launch preferences. Using
     /// this reproduces today's behavior exactly.
     public static let `default` = NookPreferenceDefaults()
 }

--- a/Sources/NookKit/App/NookPresentationPinning.swift
+++ b/Sources/NookKit/App/NookPresentationPinning.swift
@@ -55,7 +55,7 @@ public final class NookPresentationPinning {
 
     /// Monotonically increasing token assigned to each `pin()` so the broker
     /// keys by a stable identity that survives a handle's deinit (an
-    /// `ObjectIdentifier` of the handle would not — its pointer becomes
+    /// `ObjectIdentifier` of the handle would not - its pointer becomes
     /// undefined after deallocation, and ARC can drop the handle on any thread).
     private var nextToken: Int = 0
 

--- a/Sources/NookKit/App/NookResolvedTheme.swift
+++ b/Sources/NookKit/App/NookResolvedTheme.swift
@@ -11,7 +11,7 @@ import SwiftUI
 /// Resolved palette for one layout pass: respects the chrome palette, system appearance,
 /// and Reduce Transparency.
 ///
-/// Every color is built **explicitly** from black or white at a fixed opacity — never from
+/// Every color is built **explicitly** from black or white at a fixed opacity - never from
 /// system-adaptive colors like `Color.primary`. A nook lives on a non-activating panel
 /// whose SwiftUI `colorScheme` environment is unreliable, so an adaptive color could resolve
 /// for the wrong appearance (e.g. white text on the white light-mode panel). Resolving the
@@ -27,7 +27,7 @@ public struct NookResolvedTheme: Sendable {
 
     public var headerInactiveIcon: Color
 
-    /// The interactive tint for chrome controls — the active lock/gear glyphs, focus rings,
+    /// The interactive tint for chrome controls - the active lock/gear glyphs, focus rings,
     /// and the surface `.tint`. Defaults to the macOS system accent (`controlAccentColor`)
     /// so the chrome matches the user's system unless a host overrides it. Set this in a
     /// custom palette to make the chrome track *your* brand color instead of system blue.
@@ -43,7 +43,7 @@ public struct NookResolvedTheme: Sendable {
     /// directly and feed it to ``NookConfiguration/theme``; the framework's own
     /// palette is produced by ``resolve(preferences:effectiveColorScheme:reduceTransparency:)``.
     ///
-    /// Every color should be an explicit black/white-at-opacity value — see the type
+    /// Every color should be an explicit black/white-at-opacity value - see the type
     /// note above on why system-adaptive colors render wrong on the nook's panel.
     ///
     /// `accent` and `fontDesign` are defaulted, so a palette can fill only the color
@@ -135,7 +135,7 @@ public extension EnvironmentValues {
 
 public extension NookResolvedTheme {
     /// Resolves chrome using saved prefs, the **application's effective appearance** for
-    /// “Match Mac” (SwiftUI’s `colorScheme` is unreliable on menu-bar panels), and Reduce
+    /// "Match Mac" (SwiftUI's `colorScheme` is unreliable on menu-bar panels), and Reduce
     /// Transparency.
     ///
     /// Reads the appearance off `NSApplication.shared` rather than the `NSApp` global so

--- a/Sources/NookKit/App/NookStatus.swift
+++ b/Sources/NookKit/App/NookStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Severity of a transient ``NookStatus`` message — drives the banner's glyph so an
+/// Severity of a transient ``NookStatus`` message - drives the banner's glyph so an
 /// informational or success message reads differently from an error.
 ///
 /// The framework chrome stays on its minimal palette (the glyph is tinted with the

--- a/Sources/NookKit/App/NookSurfaceDriving.swift
+++ b/Sources/NookKit/App/NookSurfaceDriving.swift
@@ -14,12 +14,12 @@ import SwiftUI
 ///
 /// `AppCoordinator` owns the notch chrome but should not be welded to the concrete
 /// `Nook<AnyView, AnyView, AnyView>` generic specialization: a windowless test fake
-/// cannot be a `Nook`, and the coordinator's logic — module switching, lifecycle
-/// serialization, arbiter wiring — is what is worth testing without a real window.
+/// cannot be a `Nook`, and the coordinator's logic - module switching, lifecycle
+/// serialization, arbiter wiring - is what is worth testing without a real window.
 ///
 /// This protocol is the abstraction. It captures exactly the surface API the
 /// coordinator touches (verified against `AppCoordinator` and its extensions), and
-/// nothing more. It lives in NookKit — *not* in NookSurface, which stays MIT and thin,
+/// nothing more. It lives in NookKit - *not* in NookSurface, which stays MIT and thin,
 /// and *not* by widening `NookControllable`/`NookSurfacePresenting`. NookKit owns this
 /// protocol, so conforming the MIT `Nook` to it via a retroactive `extension` here is
 /// legal and leaves `Nook` itself untouched.
@@ -52,7 +52,7 @@ protocol NookSurfaceDriving: AnyObject {
     func hide() async
 
     /// Lifecycle hooks projected onto the surface. Re-wired on a module switch.
-    /// Explicitly `@MainActor`-isolated to match `Nook`'s contract — every observer
+    /// Explicitly `@MainActor`-isolated to match `Nook`'s contract - every observer
     /// touches main-actor state from these closures.
     var onExpand: (@MainActor () -> Void)? { get set }
     var onCompact: (@MainActor () -> Void)? { get set }
@@ -70,7 +70,7 @@ protocol NookSurfaceDriving: AnyObject {
     /// Emits on every `isLayoutGraceActive` change.
     var isLayoutGraceActivePublisher: AnyPublisher<Bool, Never> { get }
 
-    /// How the chrome presents itself — notch-fused, floating, or auto.
+    /// How the chrome presents itself - notch-fused, floating, or auto.
     var presentation: NookPresentation { get set }
 
     /// Pins the chrome window's `NSAppearance`. `nil` follows the system.

--- a/Sources/NookKit/App/NookSurfacePresenting.swift
+++ b/Sources/NookKit/App/NookSurfacePresenting.swift
@@ -11,7 +11,7 @@ import Combine
 /// the highest priority, and uses `urgent` as the bar a background module's claim must
 /// clear to reach the surface at all.
 public enum NookSurfacePriority: Int, Comparable, Sendable {
-    /// Low-stakes background cue — a volume HUD, an ambient indicator.
+    /// Low-stakes background cue - a volume HUD, an ambient indicator.
     case ambient
     /// An ordinary activity from the foreground module.
     case normal
@@ -42,14 +42,14 @@ public struct NookSurfaceClaim: Sendable {
     /// whose per-activity dwell is bounded in seconds) never trips it. The watchdog
     /// exists so a presenter that crashes mid-presentation (or never calls
     /// ``NookSurfacePresenting/endTransientPresentation(_:)``) does not accumulate
-    /// surface claims for the entire process lifetime — the stack stays bounded.
+    /// surface claims for the entire process lifetime - the stack stays bounded.
     ///
     /// Set to `nil` to disable the watchdog for an intentional long-running takeover.
     /// Set to a smaller value for a presenter that should reliably never hold the
     /// surface for more than, say, 5 seconds.
     public let maxDuration: Duration?
 
-    /// Watchdog default — 30 seconds. Long enough that no well-behaved presenter
+    /// Watchdog default - 30 seconds. Long enough that no well-behaved presenter
     /// hits it, short enough that a stuck claim is cleaned up before the user
     /// notices accumulated denials of their next claim.
     public static let defaultMaxDuration: Duration = .seconds(30)
@@ -69,7 +69,7 @@ public struct NookSurfaceClaim: Sendable {
 /// got from ``NookSurfacePresenting/beginTransientPresentation(_:)`` and passes it back
 /// to ``NookSurfacePresenting/endTransientPresentation(_:)`` to release the claim.
 ///
-/// The wrapped value carries no meaning to a presenter — it only needs to round-trip
+/// The wrapped value carries no meaning to a presenter - it only needs to round-trip
 /// the token unchanged. The initializer is public so a conformer (including a test
 /// fake) can mint tokens.
 public struct NookSurfaceToken: Hashable, Sendable {
@@ -82,7 +82,7 @@ public struct NookSurfaceToken: Hashable, Sendable {
 
 /// Coordinated, arbitrated access to the notch surface for *transient* presenters.
 ///
-/// A transient presenter — e.g. `NookComponents`' activity queue — briefly takes over
+/// A transient presenter - e.g. `NookComponents`' activity queue - briefly takes over
 /// the expanded surface, then yields it back. It must not fight the user: while the
 /// user is engaging the surface (hovering it, or having opened it themselves) a
 /// transient presenter is denied.
@@ -90,10 +90,10 @@ public struct NookSurfaceToken: Hashable, Sendable {
 /// `AppCoordinator` is the conformer; it owns the surface and arbitrates through a
 /// `SurfaceArbiter`. The protocol keeps transient presenters decoupled from
 /// `AppCoordinator`/`Nook` internals and lets them be unit-tested against a fake
-/// conformer — no real window required.
+/// conformer - no real window required.
 @MainActor
 public protocol NookSurfacePresenting: AnyObject {
-    /// `true` while the user is actively engaging the surface — hovering it, or it is
+    /// `true` while the user is actively engaging the surface - hovering it, or it is
     /// open because they opened it via show/toggle/hide. A new claim is denied while
     /// this holds.
     ///
@@ -108,18 +108,18 @@ public protocol NookSurfacePresenting: AnyObject {
     var userEngagementChanges: AnyPublisher<Bool, Never> { get }
 
     /// The id of the foreground module. A claim whose `moduleID` differs from this is
-    /// gated — granted only when its priority is `.urgent`.
+    /// gated - granted only when its priority is `.urgent`.
     var activeModuleID: String { get }
 
     /// Request the surface for a transient presentation. Returns a token when the claim
-    /// is granted, `nil` when it is denied — because the user is engaging the surface,
+    /// is granted, `nil` when it is denied - because the user is engaging the surface,
     /// because a claim of equal or higher priority already holds it, or because it is a
     /// background module's non-urgent claim. A presenter that is denied should re-queue
     /// and retry rather than render as if it owns the surface.
     func beginTransientPresentation(_ claim: NookSurfaceClaim) async -> NookSurfaceToken?
 
     /// Release a granted claim. When it was the last claim outstanding the surface
-    /// restores to the state captured before the first claim took it — unless the user
+    /// restores to the state captured before the first claim took it - unless the user
     /// has since engaged the surface, in which case their state is left untouched.
     func endTransientPresentation(_ token: NookSurfaceToken) async
 }

--- a/Sources/NookKit/App/SurfaceArbiter.swift
+++ b/Sources/NookKit/App/SurfaceArbiter.swift
@@ -14,7 +14,7 @@ import NookSurface
 /// contention with a stack of granted claims:
 ///
 /// - A claim is granted only if it outranks whatever currently holds the surface, the
-///   user is not engaging the surface, and — for a claim from a background module — its
+///   user is not engaging the surface, and - for a claim from a background module - its
 ///   priority is `.urgent`.
 /// - A higher-priority claim preempts a lower one: it is pushed on top and shows
 ///   immediately. The preempted claim stays on the stack; when it ends it simply leaves
@@ -24,7 +24,7 @@ import NookSurface
 ///
 /// The arbiter is policy only. It owns no surface state machine: every expand/compact/
 /// hide it performs is handed to `runSerial`, which threads it through
-/// `AppCoordinator.enqueueLifecycle` — the one serial chain all surface transitions run
+/// `AppCoordinator.enqueueLifecycle` - the one serial chain all surface transitions run
 /// on. The arbiter never serializes anything itself.
 @MainActor
 final class SurfaceArbiter {
@@ -41,7 +41,7 @@ final class SurfaceArbiter {
     /// token absent from this set as stale and a guaranteed no-op.
     private var liveTokens: Set<NookSurfaceToken> = []
 
-    /// The surface state captured before the first claim took the surface — what the
+    /// The surface state captured before the first claim took the surface - what the
     /// surface restores to once the stack empties. `nil` while no claim is outstanding.
     private var baseRestoreState: NookState?
 
@@ -103,8 +103,8 @@ final class SurfaceArbiter {
             // A background module reaches the surface only with an urgent claim.
             if claim.moduleID != activeModuleID(), claim.priority < .urgent { return }
             // The user owns the surface whenever they are engaging it.
-            // `isUserEngaged()` reflects user intent + hover — NOT mirror surface
-            // state — so the arbiter's own `expand()` below never trips this gate
+            // `isUserEngaged()` reflects user intent + hover - NOT mirror surface
+            // state - so the arbiter's own `expand()` below never trips this gate
             // on a subsequent preempting claim.
             if isUserEngaged() { return }
             // Only a strictly higher priority preempts the claim already on screen.
@@ -124,7 +124,7 @@ final class SurfaceArbiter {
         return granted
     }
 
-    /// Starts the wall-clock watchdog for a granted claim — a presenter that never
+    /// Starts the wall-clock watchdog for a granted claim - a presenter that never
     /// calls `endTransientPresentation` (crashed, has a bug, leaked) is the worst case
     /// this guards against. Cleaning up here keeps the stack bounded and prevents the
     /// "every subsequent claim is denied because a phantom claim still holds the
@@ -137,7 +137,7 @@ final class SurfaceArbiter {
         let moduleID = claim.moduleID
         watchdogs[token] = Task { [weak self] in
             // `Task.sleep` throws on cancellation; the typed-throws fold turns that
-            // into a nil — `end`/`invalidateClaims` cancel the task on a clean exit,
+            // into a nil - `end`/`invalidateClaims` cancel the task on a clean exit,
             // and we silently return.
             guard (try? await Task.sleep(for: maxDuration)) != nil else { return }
             guard let self else { return }
@@ -157,13 +157,13 @@ final class SurfaceArbiter {
         watchdogs.removeValue(forKey: token)?.cancel()
     }
 
-    /// Invalidates every outstanding claim owned by `moduleID` — used when that module
+    /// Invalidates every outstanding claim owned by `moduleID` - used when that module
     /// is being switched away from. Its content is leaving the surface anyway, so the
     /// claims are dropped (not transferred, not frozen) and their tokens go stale.
     ///
     /// This is a synchronous, in-memory policy mutation: it does NOT restore the surface
     /// (the switch transaction owns surface state for the incoming module) and does NOT
-    /// open its own `runSerial` — it is invoked from inside an already-open serial block.
+    /// open its own `runSerial` - it is invoked from inside an already-open serial block.
     func invalidateClaims(ownedBy moduleID: String) {
         let dropped = stack.filter { $0.claim.moduleID == moduleID }
         guard !dropped.isEmpty else { return }
@@ -178,7 +178,7 @@ final class SurfaceArbiter {
     }
 
     /// Releases the claim for `token`. When it was the last outstanding claim the
-    /// surface restores to its pre-presentation state — unless the user has since
+    /// surface restores to its pre-presentation state - unless the user has since
     /// engaged it, in which case their state is left as-is.
     ///
     /// A token whose module was switched away (or otherwise invalidated) is stale: it is
@@ -190,7 +190,7 @@ final class SurfaceArbiter {
             cancelWatchdog(for: token)
             guard let index = stack.firstIndex(where: { $0.token == token }) else { return }
             stack.remove(at: index)
-            // A surviving claim still holds the surface — leave it expanded.
+            // A surviving claim still holds the surface - leave it expanded.
             guard stack.isEmpty else { return }
 
             let restoreTo = baseRestoreState ?? .compact

--- a/Sources/NookKit/App/Views/Layout/NookLayout.swift
+++ b/Sources/NookKit/App/Views/Layout/NookLayout.swift
@@ -9,16 +9,16 @@ import SwiftUI
 
 /// Layout constants for the **demo's** expanded notch surface.
 ///
-/// The chrome itself (`NookSurface.NookView`) is content-driven — it measures whatever
+/// The chrome itself (`NookSurface.NookView`) is content-driven - it measures whatever
 /// view you hand it via `.fixedSize()` and sizes the panel to fit. `width` here is purely
 /// the demo's own choice: a stable width so the panel doesn't resize when switching
 /// between the home and settings surfaces. Building your own notch app, you set whatever
-/// width your content needs — or drop the `.frame(width:)` entirely and let it size to
+/// width your content needs - or drop the `.frame(width:)` entirely and let it size to
 /// content. Nothing in the framework requires a fixed width.
 public enum NookLayout {
     /// Default expanded-surface width, used when a host does not set
     /// ``NookConfiguration/expandedWidth``. Comfortable for the settings panels; notch apps
-    /// commonly sit in the 500–650 pt range (boring.notch 640, NotchDrop 600).
+    /// commonly sit in the 500-650 pt range (boring.notch 640, NotchDrop 600).
     public static let width: CGFloat = 520
     public static let edgePadding: CGFloat = 8
     public static let compactSlotSize: CGFloat = 24

--- a/Sources/NookKit/App/Views/ModuleRouterViews.swift
+++ b/Sources/NookKit/App/Views/ModuleRouterViews.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// Expanded-surface router. `Nook` builds its expanded content closure exactly once,
-/// so to swap modules at runtime the *view* — not the closure — must observe the
+/// so to swap modules at runtime the *view* - not the closure - must observe the
 /// ``ModuleHost``. When ``ModuleHost/configuration`` is re-published, this view's body
 /// re-evaluates and rebuilds ``NookExpandedView`` from the new configuration: new home
 /// content, new theme, new chrome opt-outs.
@@ -42,7 +42,7 @@ struct ModuleRouterExpandedView: View {
             moduleSwitcher: leadingClusterSwitcher
         )
         // Identity tracks the active module so a switch tears down the old content and
-        // inserts the new — letting the transition cross-fade rather than diff in place.
+        // inserts the new - letting the transition cross-fade rather than diff in place.
         .id(moduleHost.activeModuleID)
         .transition(.opacity)
         // Host-product identity (brand mark, About card, show-hide hotkey label) lives on
@@ -66,7 +66,7 @@ struct ModuleRouterExpandedView: View {
     }
 }
 
-/// Compact-slot router — the collapsed-pill counterpart to ``ModuleRouterExpandedView``.
+/// Compact-slot router - the collapsed-pill counterpart to ``ModuleRouterExpandedView``.
 /// One instance per slot; both observe the same ``ModuleHost`` so a module switch
 /// re-renders the leading and trailing glyphs together.
 struct ModuleRouterCompactView: View {
@@ -88,7 +88,7 @@ struct ModuleRouterCompactView: View {
             content: content
         )
         // The compact slots render in their own view tree (not under NookExpandedView),
-        // so inject the metrics here too — the default compact glyphs read
+        // so inject the metrics here too - the default compact glyphs read
         // `compactSlotSize` from it.
         .environment(\.nookChromeMetrics, configuration.metrics)
     }

--- a/Sources/NookKit/App/Views/NookExpandedView.swift
+++ b/Sources/NookKit/App/Views/NookExpandedView.swift
@@ -9,8 +9,8 @@ import AppKit
 import NookSurface
 import SwiftUI
 
-/// Top-level expanded notch surface. Renders the framework chrome — top bar plus the
-/// Settings panel — and hosts the host app's registered `home` content in between.
+/// Top-level expanded notch surface. Renders the framework chrome - top bar plus the
+/// Settings panel - and hosts the host app's registered `home` content in between.
 ///
 /// The home surface is injected, not forked: `NookConfiguration` supplies the `home`
 /// closure (defaulting to ``NookPlaceholderHomeView``). The top bar and Settings stay
@@ -18,7 +18,7 @@ import SwiftUI
 ///
 /// Sizing: the chrome sizes the panel to whatever this view measures. The demo pins a
 /// stable `NookLayout.width` so the panel doesn't resize between the home and settings
-/// surfaces — remove that `.frame(width:)` to let the panel size purely to content.
+/// surfaces - remove that `.frame(width:)` to let the panel size purely to content.
 public struct NookExpandedView: View {
     @ObservedObject var appState: AppState
 
@@ -39,7 +39,7 @@ public struct NookExpandedView: View {
     /// See ``NookConfiguration/settings``.
     let settings: (@Sendable @MainActor () -> AnyView)?
 
-    /// The framework top bar's host-configurable surface — leading cluster, top-bar
+    /// The framework top bar's host-configurable surface - leading cluster, top-bar
     /// visibility, Settings visibility. See ``NookTopBarConfiguration``.
     let topBar: NookTopBarConfiguration
 
@@ -65,7 +65,7 @@ public struct NookExpandedView: View {
     /// Insets injected by the chrome (`NookSurface`) relative to this view's
     /// outer frame. The VStack below sits inside ``NookLayout/edgePadding``, so
     /// re-inject a reduced copy of the insets for the top-bar and the host's
-    /// home/settings surface to read — they see clearance relative to their
+    /// home/settings surface to read - they see clearance relative to their
     /// own frame, not the outer one.
     @Environment(\.nookContentInsets) private var outerContentInsets
 
@@ -117,7 +117,7 @@ public struct NookExpandedView: View {
     }
 
     /// Vertical-only insets for descendants after ``columnGutter`` is applied once
-    /// on the expanded column — prevents double horizontal padding drift.
+    /// on the expanded column - prevents double horizontal padding drift.
     private var verticalContentInsets: NookContentInsets {
         NookContentInsets(top: columnGutter.top, bottom: columnGutter.bottom)
     }
@@ -231,7 +231,7 @@ public struct NookExpandedView: View {
         }
     }
 
-    /// Host-registered home surface. Supplied via ``NookConfiguration`` — no fork needed.
+    /// Host-registered home surface. Supplied via ``NookConfiguration`` - no fork needed.
     private var homeSurface: some View {
         home()
     }

--- a/Sources/NookKit/App/Views/NookPlaceholderHomeView.swift
+++ b/Sources/NookKit/App/Views/NookPlaceholderHomeView.swift
@@ -7,14 +7,14 @@
 
 import SwiftUI
 
-/// The default home surface — a placeholder shown until a host app registers its own.
+/// The default home surface - a placeholder shown until a host app registers its own.
 ///
 /// This is what `NookConfiguration` installs when no `home` content is supplied. To
 /// replace it, register your own view: `NookApp.main { MyHomeView() }`, or set
 /// ``NookConfiguration/setHome(_:)``. No need to fork the framework.
 ///
 /// It reads the resolved palette from the `\.nookResolvedTheme` environment value, which
-/// the expanded surface injects — host home views should do the same so they track the
+/// the expanded surface injects - host home views should do the same so they track the
 /// configured theme automatically.
 public struct NookPlaceholderHomeView: View {
     @Environment(\.nookResolvedTheme) private var theme

--- a/Sources/NookKit/App/Views/NookTopBar.swift
+++ b/Sources/NookKit/App/Views/NookTopBar.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///
 /// Minimal by design: a tiny home cluster on the left (matched to right-side icon
 /// weight), and the keep-open / gear glyphs on the right. The only chrome-level
-/// toggle is between the home surface and settings — everything else belongs to
+/// toggle is between the home surface and settings - everything else belongs to
 /// whatever home view a downstream fork plugs in.
 struct NookTopBar: View {
     @ObservedObject var appState: AppState
@@ -57,7 +57,7 @@ struct NookTopBar: View {
     @Environment(\.nookChromeMetrics) private var metrics
     @Environment(\.nookChromeMotion) private var motion
 
-    /// Host branding — used for the leading-cluster brand mark when no `leadingIcon` is
+    /// Host branding - used for the leading-cluster brand mark when no `leadingIcon` is
     /// configured. Injected by the expanded router. See ``NookHostBranding``.
     @Environment(\.nookHostBranding) private var branding
 
@@ -177,9 +177,9 @@ struct NookTopBar: View {
         .fixedSize(horizontal: true, vertical: false)
     }
 
-    /// On home the configured title stays visible next to its icon; in settings —
+    /// On home the configured title stays visible next to its icon; in settings - 
     /// or when a module has pushed a `moduleBreadcrumb` (a drilled-in product
-    /// sub-context) — the label collapses until the user hovers the glyph, which
+    /// sub-context) - the label collapses until the user hovers the glyph, which
     /// doubles as the back control. Clicking it exits Settings or clears the
     /// breadcrumb; the module observes that clear and pops its own sub-state.
     private var homeLeadingCluster: some View {

--- a/Sources/NookKit/App/Views/Settings/DisplaySettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/DisplaySettingsView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// Offers the two stable modes (built-in / main) plus one entry per attached display.
 /// The display list refreshes on connect/disconnect; a previously-chosen display that's
 /// since been unplugged stays selectable as a "(not connected)" row so the preference
-/// isn't silently lost — the resolver falls back to the built-in display until it returns.
+/// isn't silently lost - the resolver falls back to the built-in display until it returns.
 struct DisplaySettingsSection: View {
     @ObservedObject var appState: AppState
     @Environment(\.nookResolvedTheme) private var theme

--- a/Sources/NookKit/App/Views/Settings/HotkeySettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/HotkeySettingsView.swift
@@ -93,7 +93,7 @@ struct SettingsShortcutRow: View {
                 stopRecording()
             }
             // Swallow the event either way so it doesn't reach the rest of the app
-            // while recording — including a partial combo that isn't valid yet.
+            // while recording - including a partial combo that isn't valid yet.
             return nil
         }
     }
@@ -108,7 +108,7 @@ struct SettingsShortcutRow: View {
     }
 }
 
-/// Surfaces hotkey-registration failures for the host-configured shortcuts — the
+/// Surfaces hotkey-registration failures for the host-configured shortcuts - the
 /// module direct-jump keys and the module-cycle key. The user-rebindable show/hide
 /// shortcut reports its own failure inline in ``SettingsShortcutRow``; this row covers
 /// the static shortcuts, which would otherwise fail silently. Renders nothing when

--- a/Sources/NookKit/App/Views/Settings/SettingsDataCommandRow.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsDataCommandRow.swift
@@ -79,7 +79,7 @@ struct SettingsDataCommandRow: View {
 
 /// About card surfaced in the About settings group: host name, version, and a one-line
 /// note about the host. Name and tagline come from `\.nookHostBranding` so downstream
-/// hosts read their own product name — the demo's `"Nook"` / stock tagline are the
+/// hosts read their own product name - the demo's `"Nook"` / stock tagline are the
 /// defaults.
 struct SettingsAboutCard: View {
     @Environment(\.nookResolvedTheme) private var theme
@@ -92,7 +92,7 @@ struct SettingsAboutCard: View {
     }
 
     /// Default tagline used when the host has not overridden ``NookHostBranding/hostTagline``.
-    /// References OpenNook as the framework, not the host product — the host's
+    /// References OpenNook as the framework, not the host product - the host's
     /// own marketing copy belongs in a `hostTagline` override.
     private static let defaultTagline =
         "A demo notch app built with OpenNook, an open-source framework for macOS notch apps."

--- a/Sources/NookKit/App/Views/Settings/SettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// into one scrolling stack. Each section's content is its own file under `Views/Settings/`.
 ///
 /// Layout is deliberately flat: section label, then content, on one shared left margin
-/// (aligned with the top bar via `\.nookContentInsets`), separated by whitespace only —
+/// (aligned with the top bar via `\.nookContentInsets`), separated by whitespace only - 
 /// no card fills, no rules.
 struct SettingsView: View {
     @ObservedObject var appState: AppState
@@ -46,7 +46,7 @@ struct SettingsView: View {
     }
 
     /// Flip the haptic preference and fire one pulse on the way *on* so the user feels
-    /// what they just enabled. Off doesn't pulse — silence is its whole point.
+    /// what they just enabled. Off doesn't pulse - silence is its whole point.
     private func toggleHapticFeedback() {
         var prefs = appState.appearancePreferences
         prefs.hapticFeedbackEnabled.toggle()
@@ -122,8 +122,8 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity, maxHeight: settingsScrollMaxHeight, alignment: .leading)
     }
 
-    /// A collapsible section bound to ``expandedSections``: a disclosure header, and — when
-    /// open — the content indented under a connector hairline.
+    /// A collapsible section bound to ``expandedSections``: a disclosure header, and - when
+    /// open - the content indented under a connector hairline.
     @ViewBuilder
     private func section<Content: View>(
         _ title: String,

--- a/Sources/NookKit/App/Views/Shared/NookMark.swift
+++ b/Sources/NookKit/App/Views/Shared/NookMark.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// The OpenNook brand mark — a minimal notch arc. Pair with a center dot in
+/// The OpenNook brand mark - a minimal notch arc. Pair with a center dot in
 /// ``NookMarkView``; matches `site/public/nook-mark.svg`.
 public struct NookMark: Shape {
     public init() {}

--- a/Sources/NookKit/App/Views/Shared/NookTransientStatusBanner.swift
+++ b/Sources/NookKit/App/Views/Shared/NookTransientStatusBanner.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Transient status surfaced directly under the top bar.
 ///
-/// Reads ``AppState/status`` — a short-lived message + severity cleared on every
+/// Reads ``AppState/status`` - a short-lived message + severity cleared on every
 /// show/toggle via ``AppState/resetTransientStatus()``. The severity selects the glyph.
 struct NookTransientStatusBanner: View {
     @ObservedObject var appState: AppState

--- a/Sources/NookKit/System/HotkeyController.swift
+++ b/Sources/NookKit/System/HotkeyController.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Registers any number of global hotkeys and routes each to its own handler.
 ///
-/// A multi-module host needs more than one shortcut at a time — the show/hide toggle,
+/// A multi-module host needs more than one shortcut at a time - the show/hide toggle,
 /// a module-cycle key, a direct-jump key per module. Each registration is keyed by a
 /// caller-chosen string id so it can be replaced or removed independently; a single
 /// shared Carbon event handler dispatches presses to the right handler by hotkey id.
@@ -19,14 +19,14 @@ import Foundation
 /// the registration/dispatch dictionaries are only ever touched from the main actor.
 /// Carbon delivers `kEventHotKeyPressed` callbacks on the main thread in practice, but
 /// that is not contractually guaranteed, so the C event handler does not touch any
-/// controller state directly — it hops the lookup-and-dispatch onto the main actor via
+/// controller state directly - it hops the lookup-and-dispatch onto the main actor via
 /// `dispatchHandler(forCarbonID:)`. That makes the single-actor invariant provable
 /// rather than accidental.
 @MainActor
 public final class HotkeyController {
     /// A hotkey handler. `@Sendable` because a registration is read from the
     /// non-isolated `deinit`, and because the Carbon event callback funnels through the
-    /// main actor before invoking it — the closure genuinely crosses no unsynchronized
+    /// main actor before invoking it - the closure genuinely crosses no unsynchronized
     /// state. Callers pass `@MainActor`-isolated closures, which satisfy this.
     public typealias Handler = @Sendable () -> Void
 
@@ -52,14 +52,14 @@ public final class HotkeyController {
     /// Active registrations, keyed by the caller's string id.
     private var registrations: [String: Registration] = [:]
 
-    /// Handlers keyed by Carbon hotkey id — the dispatch table the event callback uses.
+    /// Handlers keyed by Carbon hotkey id - the dispatch table the event callback uses.
     private var handlersByCarbonID: [UInt32: Handler] = [:]
 
     private var eventHandler: CarbonRef?
 
     /// Monotonic Carbon hotkey id source. Ids are never recycled: `unregister` removes
     /// the dispatch-table entry, so a stale id can never collide with a live handler,
-    /// and `UInt32` gives ~4 billion ids — far more than any session re-registers (the
+    /// and `UInt32` gives ~4 billion ids - far more than any session re-registers (the
     /// show/hide key re-registers once per user rebind). Recycling would buy nothing and
     /// risk a freed id being reused while a Carbon event for the old binding is in flight.
     private var nextCarbonID: UInt32 = 1
@@ -86,7 +86,7 @@ public final class HotkeyController {
 
     /// Registers a global hotkey under `id`, replacing any existing registration for the
     /// same `id`. Carbon `keyCode` is a `kVK_*` virtual key code; `modifiers` is a
-    /// Carbon modifier mask (`cmdKey | optionKey | …`). Returns `noErr` on success.
+    /// Carbon modifier mask (`cmdKey | optionKey | ...`). Returns `noErr` on success.
     @discardableResult
     public func register(
         _ id: String,
@@ -147,7 +147,7 @@ public final class HotkeyController {
     /// pressed hotkey's id from the event and dispatches to the matching `Handler`.
     ///
     /// The C callback runs on whatever thread Carbon delivers the event on. It must not
-    /// touch ``handlersByCarbonID`` directly — that dictionary is main-actor state. It
+    /// touch ``handlersByCarbonID`` directly - that dictionary is main-actor state. It
     /// only decodes the hotkey id and forwards it to ``dispatchHandler(forCarbonID:)``,
     /// which performs the lookup and invocation on the main actor.
     private func installEventHandlerIfNeeded() -> OSStatus {
@@ -199,7 +199,7 @@ public final class HotkeyController {
 
     // MARK: - Test seam
 
-    /// String ids currently registered. Internal-only — for the test suite to assert
+    /// String ids currently registered. Internal-only - for the test suite to assert
     /// that `register`, `unregister`, `unregisterAll` keep the dictionary honest
     /// independent of whether `RegisterEventHotKey` actually fired (it can fail in
     /// some test environments, e.g. CI without an app context).

--- a/Sources/NookKit/System/NookHotkey.swift
+++ b/Sources/NookKit/System/NookHotkey.swift
@@ -42,7 +42,7 @@ public struct NookHotkey: Equatable, Codable, Sendable {
         return symbols
     }
 
-    /// Every glyph to render, modifiers first then the key — e.g. `["⌘", "⌥", ";"]`.
+    /// Every glyph to render, modifiers first then the key - e.g. `["⌘", "⌥", ";"]`.
     public var displaySymbols: [String] { modifierSymbols + [keySymbol] }
 
     /// Flattened display string, e.g. `"⌘⌥;"`.
@@ -51,7 +51,7 @@ public struct NookHotkey: Equatable, Codable, Sendable {
 
 public extension NookHotkey {
     /// Builds a hotkey from a captured `keyDown` event. Returns `nil` if the combination
-    /// isn't usable as a global hotkey — it must include at least one of ⌘/⌥/⌃ (a
+    /// isn't usable as a global hotkey - it must include at least one of ⌘/⌥/⌃ (a
     /// shift-only or modifier-less key makes a poor, conflict-prone global shortcut).
     init?(event: NSEvent) {
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)

--- a/Sources/NookKit/System/NookScreenLocator.swift
+++ b/Sources/NookKit/System/NookScreenLocator.swift
@@ -19,7 +19,7 @@ import CoreGraphics
 public enum NookScreenLocator {
     /// A currently-attached display, as surfaced to settings UI.
     public struct DisplayInfo: Identifiable, Equatable, Sendable {
-        /// Stable display UUID — the value stored in ``NookDisplayPreference``.
+        /// Stable display UUID - the value stored in ``NookDisplayPreference``.
         public let uuid: String
         /// Human-readable name (`NSScreen.localizedName`), e.g. "Built-in Retina Display".
         public let name: String
@@ -29,7 +29,7 @@ public enum NookScreenLocator {
         public var id: String { uuid }
     }
 
-    /// The `CGDirectDisplayID` backing a screen. Transient — valid only for the current
+    /// The `CGDirectDisplayID` backing a screen. Transient - valid only for the current
     /// display arrangement; never persist it.
     public static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
         let key = NSDeviceDescriptionKey("NSScreenNumber")
@@ -81,9 +81,9 @@ public enum NookScreenLocator {
     /// Pure fallback-chain policy: pick the index into `displays` that satisfies
     /// `preference`, degrading rather than vanishing when the chosen display is gone.
     ///
-    /// - `.specific`: the matching UUID, else built-in → main → first.
-    /// - `.builtIn`: built-in → main → first.
-    /// - `.main`: main → built-in → first.
+    /// - `.specific`: the matching UUID, else built-in -> main -> first.
+    /// - `.builtIn`: built-in -> main -> first.
+    /// - `.main`: main -> built-in -> first.
     ///
     /// Returns `nil` only when `displays` is empty. `mainIndex` is the index of the
     /// system's main display within `displays` (the AppKit path derives it from
@@ -115,7 +115,7 @@ public enum NookScreenLocator {
     ///
     /// The fallback chain keeps the chrome on-screen even when the chosen display is
     /// unplugged: a `.specific` display that isn't attached, or a `.builtIn` request on a
-    /// desktop Mac, both degrade to built-in → main → first-attached rather than vanishing.
+    /// desktop Mac, both degrade to built-in -> main -> first-attached rather than vanishing.
     /// Returns `nil` only when no display is attached at all. The policy lives in
     /// ``resolveIndex(preference:displays:mainIndex:)`` so it stays testable headlessly.
     public static func screen(matching preference: NookDisplayPreference) -> NSScreen? {

--- a/Sources/NookSurface/Internal/BlurModifier.swift
+++ b/Sources/NookSurface/Internal/BlurModifier.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt

--- a/Sources/NookSurface/Internal/NSScreen+Extensions.swift
+++ b/Sources/NookSurface/Internal/NSScreen+Extensions.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -9,7 +9,7 @@
 import SwiftUI
 
 extension NSScreen {
-    /// Heuristic — Apple notched displays expose auxiliary widths on both sides of the camera.
+    /// Heuristic - Apple notched displays expose auxiliary widths on both sides of the camera.
     var hasNotch: Bool {
         auxiliaryTopLeftArea?.width != nil && auxiliaryTopRightArea?.width != nil
     }

--- a/Sources/NookSurface/Internal/Nook+Drag.swift
+++ b/Sources/NookSurface/Internal/Nook+Drag.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -19,7 +19,7 @@ import AppKit
 // transitions are idempotent.
 //
 // Lives in its own file so `Nook.swift` stays focused on lifecycle/transition
-// concerns. The stored `dragSession` property is still declared on `Nook` itself —
+// concerns. The stored `dragSession` property is still declared on `Nook` itself - 
 // only the surrounding state machine and the destination-callback conformance
 // extract here.
 
@@ -31,8 +31,8 @@ extension Nook {
     /// guarantee a state machine can lean on: `draggingExited` can arrive *before*
     /// `draggingEnded` for one session, a slow or rejected `onFileDrop` can let a fresh
     /// `draggingEntered` interleave, and `draggingUpdated` fires repeatedly. Rather than
-    /// scatter `stateBeforeDrag`/`isDragInFlight` mutations across those entry points —
-    /// correct only by luck of ordering — the whole session lives in this one enum with
+    /// scatter `stateBeforeDrag`/`isDragInFlight` mutations across those entry points - 
+    /// correct only by luck of ordering - the whole session lives in this one enum with
     /// idempotent transitions.
     enum DragSession: Equatable {
         /// No drag over the panel.
@@ -52,7 +52,7 @@ extension Nook: NookDragDestination {
     /// idempotent no-ops that preserve the original snapshot.
     func nookPanelDraggingEntered(_ urls: [URL]) -> NSDragOperation {
         guard case .idle = dragSession else {
-            // Already active — a forwarded `draggingUpdated`, or a duplicate enter.
+            // Already active - a forwarded `draggingUpdated`, or a duplicate enter.
             // Keep the original snapshot; the advertised operation is unchanged.
             return .copy
         }
@@ -89,7 +89,7 @@ extension Nook: NookDragDestination {
     }
 
     /// End the current drag session exactly once. Reads the snapshot out of the session
-    /// state, flips it to `.idle`, and — if asked — restores the captured prior state.
+    /// state, flips it to `.idle`, and - if asked - restores the captured prior state.
     /// Calling this when already `.idle` is a no-op, which is what makes the destination
     /// robust against AppKit's duplicate and out-of-order exit/end/drop callbacks.
     private func endDragSession(restorePriorState: Bool) {

--- a/Sources/NookSurface/Internal/NookDragDestination.swift
+++ b/Sources/NookSurface/Internal/NookDragDestination.swift
@@ -9,12 +9,12 @@ import AppKit
 /// Handler the panel calls when a system drag session enters / exits / drops on its window.
 ///
 /// `NookPanel` covers the full top half of the screen (because the panel itself is the
-/// drag-receiving region — the visible notch silhouette is just a clip mask), so any
+/// drag-receiving region - the visible notch silhouette is just a clip mask), so any
 /// file drag aimed even loosely at the menu-bar area lands here. The chrome is the
 /// SwiftUI surface; the panel just relays drag-session lifecycle calls into the `Nook`
 /// that owns it.
 ///
-/// `@MainActor` — AppKit delivers drag-session callbacks on the main thread, and the
+/// `@MainActor` - AppKit delivers drag-session callbacks on the main thread, and the
 /// conformer (`Nook`) is main-actor-isolated.
 @MainActor
 protocol NookDragDestination: AnyObject {
@@ -22,7 +22,7 @@ protocol NookDragDestination: AnyObject {
     /// the dragging source (`.copy` registers the green "+" badge users expect).
     func nookPanelDraggingEntered(_ urls: [URL]) -> NSDragOperation
 
-    /// Drag left without dropping — restore prior state.
+    /// Drag left without dropping - restore prior state.
     func nookPanelDraggingExited()
 
     /// Drop landed. Returning `true` tells AppKit the drop was accepted.

--- a/Sources/NookSurface/Internal/NookFeedbackEvent.swift
+++ b/Sources/NookSurface/Internal/NookFeedbackEvent.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt

--- a/Sources/NookSurface/Internal/NookFeedbackOverlay.swift
+++ b/Sources/NookSurface/Internal/NookFeedbackOverlay.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -14,14 +14,14 @@ import SwiftUI
 /// Implementation strategy: a `TimelineView` advances `progress = (now − startedAt) / duration`
 /// in the 0...1 range. The shimmer is a `LinearGradient` whose `startPoint` / `endPoint` slide
 /// across the unit square so a 0.5-unit-wide bright band moves from off-screen leading to
-/// off-screen trailing — masked onto a stroked ``NookShape`` so only the chrome's perimeter
+/// off-screen trailing - masked onto a stroked ``NookShape`` so only the chrome's perimeter
 /// receives light. Once `progress` hits 1 the overlay renders `Color.clear`; the model then
-/// nils ``Nook/feedbackEvent`` (see ``Nook/setFeedbackEvent(_:)``) so this whole branch — and
-/// its `TimelineView` — drops from the view tree until the next event lands. Repeating cues
+/// nils ``Nook/feedbackEvent`` (see ``Nook/setFeedbackEvent(_:)``) so this whole branch - and
+/// its `TimelineView` - drops from the view tree until the next event lands. Repeating cues
 /// keep the timeline alive by design.
 ///
 /// Because the animation is a pure function of `(now, startedAt, duration)`, no `@State`
-/// reset choreography is needed when a new event preempts an in-flight one — bumping
+/// reset choreography is needed when a new event preempts an in-flight one - bumping
 /// ``Nook/feedbackEvent`` re-anchors `startedAt` and the gradient picks up at progress 0
 /// the next frame.
 ///
@@ -55,7 +55,7 @@ struct NookFeedbackOverlay: View {
 
     /// One-shot events advance linearly and clamp at 1. Repeating events wrap with modulo so
     /// the animation reaches `progress=1` (the natural fade-out point of each cycle), rolls
-    /// back to 0, and starts again — every iteration is visually identical to the first.
+    /// back to 0, and starts again - every iteration is visually identical to the first.
     private func progressValue(for event: NookFeedbackEvent, elapsed: TimeInterval) -> Double {
         guard event.duration > 0 else { return 1 }
         if event.repeats {
@@ -81,8 +81,8 @@ struct NookFeedbackOverlay: View {
     /// at p=1 it's just off-screen right (1.0, 1.5). Total travel = 1.5 unit-widths in
     /// `duration` seconds.
     ///
-    /// `envelope = sin(p · π)` ramps the overall opacity 0 → 1 → 0 over the same window so the
-    /// band fades in as it enters the visible region and fades out as it leaves — no hard
+    /// `envelope = sin(p · π)` ramps the overall opacity 0 -> 1 -> 0 over the same window so the
+    /// band fades in as it enters the visible region and fades out as it leaves - no hard
     /// edges at the start/end frames.
     private func shimmerSweep(event: NookFeedbackEvent, progress: Double) -> some View {
         let startX = -0.5 + progress * 1.5
@@ -104,7 +104,7 @@ struct NookFeedbackOverlay: View {
         )
 
         return ZStack {
-            // Soft ambient halo that pulses with the shimmer — gives the perimeter weight at
+            // Soft ambient halo that pulses with the shimmer - gives the perimeter weight at
             // peripheral vision so the cue reads even when the user isn't directly looking.
             NookShape(form: form, topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius)
                 .stroke(event.tint.opacity(0.55), lineWidth: 8.0)

--- a/Sources/NookSurface/Internal/NookPanel.swift
+++ b/Sources/NookSurface/Internal/NookPanel.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -14,8 +14,8 @@ final class NookPanel: NSPanel {
     ///
     /// `.screenSaver` (the next named level above `.statusBar`) is silently
     /// undeliverable for system drag sessions, so we stay below it. The exact magnitude
-    /// is not load-bearing — any value strictly between `.statusBar` (25) and
-    /// `.screenSaver` (1000) works the same — but `+8` mirrors AppKit's own spacing
+    /// is not load-bearing - any value strictly between `.statusBar` (25) and
+    /// `.screenSaver` (1000) works the same - but `+8` mirrors AppKit's own spacing
     /// between adjacent named window levels and leaves headroom for a host to layer
     /// transient surfaces above the chrome without rewriting this offset.
     static let levelOffsetAboveStatusBar: Int = 8
@@ -56,10 +56,10 @@ final class NookPanel: NSPanel {
 
 /// Transparent overlay view that intercepts AppKit drag-and-drop events and forwards
 /// them to a `NookDragDestination`. Sits on top of the SwiftUI hosting view so drag
-/// events reach us before `NSHostingView` swallows them — `hitTest(_:)` returns `nil`
+/// events reach us before `NSHostingView` swallows them - `hitTest(_:)` returns `nil`
 /// so mouse events pass through to the SwiftUI surface untouched.
 ///
-/// Drag handling can't live on the panel itself — `NSDraggingDestination` is informal
+/// Drag handling can't live on the panel itself - `NSDraggingDestination` is informal
 /// on `NSWindow` in Swift, and `NSHostingView` has its own internal drag-types
 /// registration that consumes events before they reach a parent NSView. Routing
 /// through this overlay is the standard AppKit pattern that survives both.
@@ -79,7 +79,7 @@ final class NookDragInterceptingView: NSView {
     /// Pass mouse events through to whatever sits below us in the view hierarchy
     /// (the SwiftUI hosting view). Drag-and-drop uses a separate AppKit code path
     /// that doesn't go through `hitTest(_:)`, so this only neutralizes pointer
-    /// interactions — drag events still land in `draggingEntered(_:)` etc.
+    /// interactions - drag events still land in `draggingEntered(_:)` etc.
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
     }
@@ -90,7 +90,7 @@ final class NookDragInterceptingView: NSView {
         return dragDestination?.nookPanelDraggingEntered(urls) ?? []
     }
 
-    /// Forward updates as `entered` again — `Nook` is idempotent on enter — so the
+    /// Forward updates as `entered` again - `Nook` is idempotent on enter - so the
     /// returned drag operation stays accurate as the cursor moves within the view.
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
         let urls = readFileURLs(from: sender.draggingPasteboard)

--- a/Sources/NookSurface/Internal/NookShape.swift
+++ b/Sources/NookSurface/Internal/NookShape.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -10,15 +10,15 @@ import SwiftUI
 
 /// The chrome's outline. Two forms, selected by ``NookChromeForm``:
 ///
-/// - ``NookChromeForm/notch`` — a notch-following shape: the top edge flares to full
+/// - ``NookChromeForm/notch`` - a notch-following shape: the top edge flares to full
 ///   width then curves *inward* by `topCornerRadius`, so the ears fuse flush with the
 ///   menu bar on either side of a physical notch; larger bottom-corners where the
 ///   panel meets the wallpaper.
-/// - ``NookChromeForm/floating`` — a plain convex rounded rectangle, for a free-floating
+/// - ``NookChromeForm/floating`` - a plain convex rounded rectangle, for a free-floating
 ///   panel on a display with no notch.
 ///
 /// `form` is a discrete per-window configuration and isn't animated; the two corner
-/// radii are, so a compact↔expanded transition still springs smoothly within a form.
+/// radii are, so a compact<->expanded transition still springs smoothly within a form.
 struct NookShape: Shape {
     private let form: NookChromeForm
     private var topCornerRadius: CGFloat
@@ -82,7 +82,7 @@ struct NookShape: Shape {
     }
 
     /// Convex rounded rectangle flush to `rect`, with independent top and bottom corner
-    /// radii. No flared ears — this is a panel that floats on its own, not one fused to
+    /// radii. No flared ears - this is a panel that floats on its own, not one fused to
     /// a notch. Radii are clamped so they can't overrun a small compact pill.
     private func floatingPath(in rect: CGRect) -> Path {
         let limit = min(rect.width, rect.height) / 2

--- a/Sources/NookSurface/Internal/NookView.swift
+++ b/Sources/NookSurface/Internal/NookView.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -31,13 +31,13 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     }
 
     /// `true` when the surface should render the free-floating panel instead of the
-    /// notch-fused shape — a display with no notch, or a forced `.floating` presentation.
+    /// notch-fused shape - a display with no notch, or a forced `.floating` presentation.
     private var isFloating: Bool {
         nook.layoutForm == .floating
     }
 
     /// Residual safe-area insets the host's expanded view can read via
-    /// ``EnvironmentValues/nookContentInsets``. `.zero` while compact or hidden —
+    /// ``EnvironmentValues/nookContentInsets``. `.zero` while compact or hidden - 
     /// no host expanded content is rendered in those states. The expanded value
     /// is the geometric clearance left over after the chrome's own paddings;
     /// see ``NookContentInsets/expanded(form:topCornerRadius:bottomCornerRadius:chromeSafeAreaInset:)``.
@@ -59,7 +59,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
         (top: 6, bottom: 14)
     }
 
-    /// Floating panels use convex corners — a card when expanded, a capsule when
+    /// Floating panels use convex corners - a card when expanded, a capsule when
     /// compact (radius = half the pill height). No notch ears to fuse, so the same
     /// radius applies to all four corners.
     private var floatingExpandedRadius: CGFloat { expandedCornerRadii.bottom }
@@ -104,11 +104,11 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
 
     /// Backdrop sits behind chrome content, both flattened into a single layer, then clipped
     /// to the animatable notch shape. Compositing as one group means the spring animation can
-    /// scale content + backdrop atomically — no magic overshoot padding required to plug
+    /// scale content + backdrop atomically - no magic overshoot padding required to plug
     /// edge gaps mid-bounce.
     ///
     /// The matching `.contentShape(NookShape)` is critical: `.clipShape` only clips drawing,
-    /// not hit-testing. Without it, the hover region falls back to the rectangular bounds —
+    /// not hit-testing. Without it, the hover region falls back to the rectangular bounds - 
     /// which extend down into the would-be-expanded area because the expanded content's
     /// `.fixedSize()` doesn't actually collapse to 0×0 when wrapped in a max-frame. Result:
     /// hovering in the empty space below a compact nook triggers the hover-grow animation.
@@ -132,7 +132,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
 
     /// Peripheral cue overlay. Sits above backdrop+content but inside the compositing group,
     /// so the shimmer stroke flattens with the chrome before the notch shape carves the visible
-    /// region — no edge gaps mid-bounce, no spillover beyond the arch.
+    /// region - no edge gaps mid-bounce, no spillover beyond the arch.
     private func feedbackOverlay() -> some View {
         NookFeedbackOverlay(
             event: nook.feedbackEvent,
@@ -205,7 +205,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
         }()
         Color.clear
             .glassEffect(tinted, in: notchShape)
-            // The legibility pass is whatever the spec carries — the surface adds no
+            // The legibility pass is whatever the spec carries - the surface adds no
             // darken of its own on top of Apple's self-contrasting material.
             .overlay { glassShading(glass) }
     }
@@ -213,7 +213,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
 
     /// The host-supplied legibility shading, rendered as a gradient. `nil` shading draws
     /// nothing, leaving the glass pristine. The gradient, its stops, and its direction all
-    /// come from the ``NookBackdrop/LiquidGlass`` spec — the surface never substitutes its
+    /// come from the ``NookBackdrop/LiquidGlass`` spec - the surface never substitutes its
     /// own, so a host can shape the falloff however it likes.
     @ViewBuilder
     private func glassShading(_ glass: NookBackdrop.LiquidGlass) -> some View {
@@ -227,7 +227,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     }
 
     /// Pre-Tahoe approximation: a glassy material, an optional tint, a legibility darken,
-    /// then the specular treatment that actually reads as "glass" — a top-down sheen and
+    /// then the specular treatment that actually reads as "glass" - a top-down sheen and
     /// a bright rim traced along ``notchShape``. The outer `.clipShape` trims the rim's
     /// outer half, leaving an inner highlight along the edge.
     @ViewBuilder
@@ -300,7 +300,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
             }
 
             // Notch mode: a gap exactly the notch width, so the leading/trailing slots
-            // straddle the physical notch. Floating mode: no notch — just a small gap
+            // straddle the physical notch. Floating mode: no notch - just a small gap
             // keeping the two slots from touching inside the pill.
             Spacer()
                 .frame(width: isFloating ? 8 : nook.notchSize.width)
@@ -315,7 +315,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
             }
         }
         .frame(height: nook.notchSize.height)
-        // `disableCompactLeading/Trailing` are construction-time `let`s on `Nook` —
+        // `disableCompactLeading/Trailing` are construction-time `let`s on `Nook` - 
         // they cannot change at runtime, so no `.onChange` reconciliation is needed.
         // The `@State` `compactLeadingWidth`/`compactTrailingWidth` retain their last
         // measured value when the slot views disappear (SwiftUI doesn't fire

--- a/Sources/NookSurface/Internal/VisualEffectView.swift
+++ b/Sources/NookSurface/Internal/VisualEffectView.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt

--- a/Sources/NookSurface/Nook.swift
+++ b/Sources/NookSurface/Nook.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -13,9 +13,9 @@ import SwiftUI
 /// A notch-pinned floating panel with `expanded` / `compact` / `hidden` states.
 ///
 /// Three SwiftUI view types compose the surface:
-/// - `Expanded` — the full panel that drops below the menu-bar notch.
-/// - `CompactLeading` — the slot to the left of the notch when collapsed.
-/// - `CompactTrailing` — the slot to the right of the notch when collapsed.
+/// - `Expanded` - the full panel that drops below the menu-bar notch.
+/// - `CompactLeading` - the slot to the left of the notch when collapsed.
+/// - `CompactTrailing` - the slot to the right of the notch when collapsed.
 ///
 /// Driving the lifecycle:
 /// ```swift
@@ -42,7 +42,7 @@ import SwiftUI
 @MainActor
 public final class Nook<Expanded, CompactLeading, CompactTrailing>: ObservableObject, NookControllable
 where Expanded: View, CompactLeading: View, CompactTrailing: View {
-    /// The chrome's window controller, or `nil` while hidden. **Internal-only** — the
+    /// The chrome's window controller, or `nil` while hidden. **Internal-only** - the
     /// supported host seam for window inspection is ``hasLiveWindow``, and the
     /// supported mutation seam is ``configureWindow(_:)``. Exposing the controller
     /// publicly let hosts call `windowController?.close()` and tear the panel out
@@ -50,7 +50,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     var windowController: NSWindowController?
 
     /// `true` while the chrome has a live `NSWindow` mounted. The narrow public
-    /// surface area for observing window presence — replaces the previous
+    /// surface area for observing window presence - replaces the previous
     /// `windowController != nil` pattern hosts had to write.
     public var hasLiveWindow: Bool { windowController?.window != nil }
 
@@ -76,17 +76,17 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
 
     /// Resolves the screen the chrome should occupy when a caller doesn't pass one
     /// explicitly. Host apps set this to project a persisted display preference
-    /// (built-in / main / a specific display) onto the surface — the closure is
+    /// (built-in / main / a specific display) onto the surface - the closure is
     /// consulted on every `expand`/`compact` with a `nil` screen, on hover-driven
     /// transitions, and whenever the display set changes. Returning `nil` falls
     /// through to the window's current screen, then the system's main screen.
     ///
     /// Explicitly `@MainActor`-isolated because it touches `NSScreen` and is invoked
-    /// from `@MainActor` paths — the annotation makes that contract explicit to a
+    /// from `@MainActor` paths - the annotation makes that contract explicit to a
     /// host setting it from a non-isolated context.
     public var screenProvider: (@MainActor () -> NSScreen?)?
 
-    /// How the chrome presents itself — notch-fused, free-floating, or `.auto` (notch on
+    /// How the chrome presents itself - notch-fused, free-floating, or `.auto` (notch on
     /// a notched display, floating elsewhere). See ``NookPresentation``.
     ///
     /// The effective layout is resolved per-window against the target screen; changing
@@ -103,20 +103,20 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     let compactLeadingContent: CompactLeading
     let compactTrailingContent: CompactTrailing
     /// Construction-time flags set by the no-compact convenience init. Immutable so
-    /// they can't be flipped mid-flight and trip the view's transition heuristics —
+    /// they can't be flipped mid-flight and trip the view's transition heuristics - 
     /// the no-compact case is a build-time choice, not runtime state.
     let disableCompactLeading: Bool
     let disableCompactTrailing: Bool
 
     /// Current lifecycle state. Host apps can observe this directly (it's `@Published`)
-    /// or react through the ``onExpand`` / ``onCompact`` / ``onHide`` callbacks — the
+    /// or react through the ``onExpand`` / ``onCompact`` / ``onHide`` callbacks - the
     /// callbacks fire on every transition, including hover- and drag-driven ones that
     /// never pass through a host-called `expand`/`compact`.
     @Published public private(set) var state: NookState = .hidden
     @Published private(set) var notchSize: CGSize = .zero
     @Published private(set) var menubarHeight: CGFloat = 0
 
-    /// Layout resolved for the current window's screen — `.notch` or `.floating`.
+    /// Layout resolved for the current window's screen - `.notch` or `.floating`.
     /// Recomputed every time the panel window is built (see `initializeWindow`); drives
     /// `NookView`'s shape and positioning.
     @Published private(set) var layoutForm: NookChromeForm = .notch
@@ -132,7 +132,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// in the expanded surface and the auto-expand from compact. The panel surfaces
     /// `NSDraggingDestination` callbacks; this published bool is the SwiftUI-friendly view.
     ///
-    /// This is a derived mirror of ``dragSession`` — kept as the published surface for
+    /// This is a derived mirror of ``dragSession`` - kept as the published surface for
     /// observers (`AppCoordinator` subscribes to `$isDragInFlight`). The authoritative
     /// session state is ``dragSession``; this bool is updated from its `didSet`.
     @Published public private(set) var isDragInFlight: Bool = false
@@ -141,16 +141,16 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// Returning `true` accepts the drop; `false` rejects it.
     ///
     /// This is the engine's product-agnostic seam, not a "file import" feature. The engine
-    /// only does presentation-container work — it extracts URLs from the drag pasteboard,
+    /// only does presentation-container work - it extracts URLs from the drag pasteboard,
     /// auto-expands a collapsed panel so a drop target is visible (drag-to-reveal), and
     /// hands the raw URLs to this callback. It does not interpret, store, or copy the
-    /// files. Whatever the URLs *mean* — a shelf, an import flow, a no-op — is entirely the
+    /// files. Whatever the URLs *mean* - a shelf, an import flow, a no-op - is entirely the
     /// app layer's concern; the engine never sees it.
     ///
     /// `@MainActor`-isolated: invoked from the surface's main-actor drag pipeline.
     public var onFileDrop: (@MainActor ([URL]) -> Bool)?
 
-    /// Fired when the chrome transitions **into** the expanded surface — from any source:
+    /// Fired when the chrome transitions **into** the expanded surface - from any source:
     /// a host-called `expand`, a hover-grow, or a file drag auto-expanding the panel.
     public var onExpand: (@MainActor () -> Void)?
 
@@ -161,8 +161,8 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// sequence collapses to compact, so `onHide` only fires on a genuine hide afterwards.
     public var onHide: (@MainActor () -> Void)?
 
-    /// Authoritative state of the in-flight file-drag session. The whole session — the
-    /// pre-drag `NookState` snapshot and whether a drag is over the panel at all — lives
+    /// Authoritative state of the in-flight file-drag session. The whole session - the
+    /// pre-drag `NookState` snapshot and whether a drag is over the panel at all - lives
     /// in this single enum so AppKit's uncoordinated enter/update/exit/end/drop callbacks
     /// cannot corrupt it (see ``DragSession``). ``isDragInFlight`` is kept in sync from
     /// the `didSet` so existing observers of that published bool are unaffected.
@@ -174,7 +174,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
         }
     }
 
-    /// What the chrome paints behind compact + expanded content — vibrancy or solid.
+    /// What the chrome paints behind compact + expanded content - vibrancy or solid.
     @Published public var backdrop: NookBackdrop = .solidBlack
 
     /// Pins the chrome window's `NSAppearance`. `nil` follows the system appearance.
@@ -186,13 +186,13 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     ///
     /// **Deliberately not `@Published`** (unlike ``backdrop``). `NSAppearance` is an
     /// AppKit appearance proxy whose effect is the `NSWindow.appearance` set in
-    /// ``didSet`` — the SwiftUI content tree re-resolves its `colorScheme` from the
+    /// ``didSet`` - the SwiftUI content tree re-resolves its `colorScheme` from the
     /// hosting window automatically. There is no SwiftUI observer that would benefit
     /// from a Combine publish, so adding `@Published` would be theatrical motion
     /// without behavioural change.
     public var chromeAppearance: NSAppearance? {
         didSet {
-            // Pinning the appearance only pokes the live window — no rebuild — so unlike
+            // Pinning the appearance only pokes the live window - no rebuild - so unlike
             // `presentation` this needs no generation bump; an in-flight transition is
             // unaffected by an `NSAppearance` swap on the same window.
             windowController?.window?.appearance = chromeAppearance
@@ -213,18 +213,18 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// overlay's `TimelineView(.animation)` keeps ticking at 60fps forever after the cue ends
     /// (it only renders `Color.clear`, but the timeline never stops). Nilling the event lets
     /// `NookFeedbackOverlay` take its `else` branch and drop the timeline from the tree.
-    /// Repeating cues are exempt — they're meant to run until acknowledged.
+    /// Repeating cues are exempt - they're meant to run until acknowledged.
     private var feedbackClearTask: Task<Void, Never>?
 
-    /// The in-flight transition — expand, compact, *or hide* — or `nil` when idle.
+    /// The in-flight transition - expand, compact, *or hide* - or `nil` when idle.
     /// ``runTransition(_:)`` cancels this before spawning a replacement, so a superseded
     /// transition's `Task.sleep` throws promptly instead of running to term. The hide
     /// teardown now runs as one of these tracked tasks (it used to live in a separate,
-    /// untracked `closePanelTask` outside the generation system — see ``_hide(generation:)``).
+    /// untracked `closePanelTask` outside the generation system - see ``_hide(generation:)``).
     private var transitionTask: Task<Void, Never>?
 
     /// Monotonic transition token. ``runTransition(_:)`` bumps it **synchronously** at
-    /// each entry point — hover, drag, public `expand`/`compact` — so the token reflects
+    /// each entry point - hover, drag, public `expand`/`compact` - so the token reflects
     /// call order, not the order tasks happen to start running. A transition re-checks
     /// it via ``isCurrent(_:)`` at its top and after every suspension, and bails if a
     /// newer one has superseded it. This makes rapid hover-in/hover-out resolve cleanly
@@ -258,7 +258,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     }
 
     /// Internal designated init for the no-compact-content case. The `disableCompact*`
-    /// flags are stored as `let` so they can't drift at runtime — the no-compact case
+    /// flags are stored as `let` so they can't drift at runtime - the no-compact case
     /// is a build-time choice.
     private init(
         hoverBehavior: NookHoverBehavior,
@@ -319,8 +319,8 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     }
 
     /// Fire the host's lifecycle callbacks on every distinct state transition. A single
-    /// `$state` sink catches transitions from *all* sources uniformly — host-called
-    /// `expand`/`compact`, hover-driven grow/shrink, drag auto-expand — which is why the
+    /// `$state` sink catches transitions from *all* sources uniformly - host-called
+    /// `expand`/`compact`, hover-driven grow/shrink, drag auto-expand - which is why the
     /// hooks live here rather than on a higher-level coordinator. `dropFirst()` skips the
     /// initial `.hidden` published at construction; `removeDuplicates()` collapses no-op
     /// re-publishes so a hook never double-fires for one logical transition.
@@ -366,7 +366,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// `Nook` and frees us from an unstructured `Task` whose cancellation we never
     /// wired up.
     ///
-    /// While hidden there's no window worth keeping — drop any stale one so the next
+    /// While hidden there's no window worth keeping - drop any stale one so the next
     /// `expand`/`compact` rebuilds on the then-current preferred screen. While visible,
     /// recompute the target via ``resolvedScreen`` and re-show there, so a host's
     /// display preference (and its disconnect fallback) follows the chrome live.
@@ -430,7 +430,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
     /// suspension. The returned task completes when `body` does, so an `await`ing caller
     /// (e.g. `expand()`) sees the transition through to settle.
     ///
-    /// Every transition — expand, compact, **and hide** — flows through here, so a new
+    /// Every transition - expand, compact, **and hide** - flows through here, so a new
     /// transition reliably supersedes whatever was in flight: the generation bump fails
     /// the predecessor's next `isCurrent` check, and the `cancel()` stops it sleeping.
     /// In particular a hover- or drag-driven `expand` cancels an in-flight hide's
@@ -450,7 +450,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
         return task
     }
 
-    /// `true` while `generation` is still the most recent transition — i.e. no newer
+    /// `true` while `generation` is still the most recent transition - i.e. no newer
     /// `expand`/`compact`/`hide` has been claimed since.
     func isCurrent(_ generation: Int) -> Bool { transitionGeneration == generation }
 
@@ -471,7 +471,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
 
     /// Rebuild a currently-visible window in place (new screen, new presentation) so the
     /// new layout takes effect immediately. Supersedes any in-flight transition first so
-    /// it can't keep mutating the window being swapped — see ``supersedeInFlightTransition()``.
+    /// it can't keep mutating the window being swapped - see ``supersedeInFlightTransition()``.
     func rebuildVisibleWindow(on screen: NSScreen) {
         supersedeInFlightTransition()
         initializeWindow(screen: screen, orderFront: false)
@@ -483,7 +483,7 @@ where Expanded: View, CompactLeading: View, CompactTrailing: View {
 
 public extension Nook {
     /// Expand the chrome. Pass `nil` (the default) to let ``resolvedScreen`` pick the
-    /// target — typically the host's persisted display preference via ``screenProvider``.
+    /// target - typically the host's persisted display preference via ``screenProvider``.
     func expand(on screen: NSScreen? = nil) async {
         guard let target = screen ?? resolvedScreen else { return }
         let skipHide = transitionConfiguration.skipIntermediateHides
@@ -502,8 +502,8 @@ public extension Nook {
         }.value
     }
 
-    /// Hide the chrome and tear the window down. Routed through ``runTransition(_:)`` —
-    /// exactly like `expand`/`compact` — so the hide and its teardown live fully inside
+    /// Hide the chrome and tear the window down. Routed through ``runTransition(_:)`` - 
+    /// exactly like `expand`/`compact` - so the hide and its teardown live fully inside
     /// the generation system: a newer transition reliably supersedes an in-flight hide,
     /// cancelling its task before its `fadeOutWindow`/`deinitializeWindow` can run.
     func hide() async {
@@ -519,8 +519,8 @@ public extension Nook {
     /// Play a one-shot peripheral cue along the chrome's perimeter. Default is the shimmer sweep.
     ///
     /// Use this for low-priority "something happened" signals the user can catch in
-    /// peripheral vision — a sync finished, a background task completed. Caller-owned
-    /// timing — no internal queueing or debouncing; rapid successive calls re-anchor
+    /// peripheral vision - a sync finished, a background task completed. Caller-owned
+    /// timing - no internal queueing or debouncing; rapid successive calls re-anchor
     /// `startedAt` and the in-flight animation restarts. A cue requested while the chrome
     /// is hidden is queued and replayed the next time the nook becomes visible.
     func playFeedback(
@@ -541,7 +541,7 @@ public extension Nook {
         )
         switch state {
         case .compact, .expanded:
-            // Chrome is visible (either as compact pill or expanded surface) — fire
+            // Chrome is visible (either as compact pill or expanded surface) - fire
             // immediately. The shimmer overlay strokes the same `NookShape` perimeter in
             // both states, so the visual reads on either.
             setFeedbackEvent(event)
@@ -569,7 +569,7 @@ extension Nook {
         feedbackClearTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
             guard !Task.isCancelled, let self else { return }
-            // Only clear if this is still the event we armed for — a newer cue (which cancels
+            // Only clear if this is still the event we armed for - a newer cue (which cancels
             // this task) or a repeating cue must not be nilled out from under the overlay.
             if self.feedbackEvent?.id == id { self.feedbackEvent = nil }
             self.feedbackClearTask = nil
@@ -579,8 +579,8 @@ extension Nook {
 
 extension Nook {
     /// Expand the chrome onto `screen`. Runs on the main actor and `await`s the
-    /// transition to completion — including a settle pass that lets the open or
-    /// conversion animation finish — so an awaited `expand()` returns once the chrome
+    /// transition to completion - including a settle pass that lets the open or
+    /// conversion animation finish - so an awaited `expand()` returns once the chrome
     /// has visibly arrived, not after an unrelated fixed delay.
     ///
     /// `generation` is the token claimed synchronously by ``runTransition(_:)``. The
@@ -590,7 +590,7 @@ extension Nook {
         // Superseded before this task even started running.
         guard isCurrent(generation) else { return }
 
-        // Opening the nook acknowledges any *repeating* peripheral cue — those are
+        // Opening the nook acknowledges any *repeating* peripheral cue - those are
         // meant to keep nagging until the user looks, so once they're looking we kill
         // them. A one-shot cue (e.g. the launch shimmer greeting) is allowed to play
         // through the expand transition so the user actually sees it; the perimeter
@@ -603,7 +603,7 @@ extension Nook {
         if feedbackEvent?.repeats == true { feedbackEvent = nil }
         if pendingFeedback?.repeats == true { pendingFeedback = nil }
 
-        // Already expanded *on the requested screen* — nothing to do. A different
+        // Already expanded *on the requested screen* - nothing to do. A different
         // screen still needs work: the window must move, so fall through to the
         // rebuild path, which `needsNewWindow` below already handles.
         if state == .expanded, windowController?.window?.screen == screen { return }
@@ -617,7 +617,7 @@ extension Nook {
             try? await Task.sleep(for: openSettleDuration)
             // A screen-parameter change during the settle could have rebuilt the
             // window underneath us; bail rather than return success on a defunct view.
-            // `Task.isCancelled` belt-and-suspenders matches `_hide`'s pattern — a
+            // `Task.isCancelled` belt-and-suspenders matches `_hide`'s pattern - a
             // cancellation can only come from a generation-bumping supersession today,
             // so this is redundant with `isCurrent`, but the two together make the
             // bail condition robust against any future cancellation path.
@@ -642,7 +642,7 @@ extension Nook {
         guard isCurrent(generation) else { return }
 
         if disableCompactLeading, disableCompactTrailing {
-            // No compact content to show — "compact" collapses to a full hide. Run the
+            // No compact content to show - "compact" collapses to a full hide. Run the
             // hide *inline on this same generation* rather than calling the public
             // `hide()`: the latter claims a fresh generation via `runTransition` and
             // would supersede the very transition we're inside, dropping our teardown.
@@ -650,7 +650,7 @@ extension Nook {
             return
         }
 
-        // Already compact *on the requested screen* — nothing to do. A different
+        // Already compact *on the requested screen* - nothing to do. A different
         // screen still needs the window moved, so fall through to the rebuild path.
         if state == .compact, windowController?.window?.screen == screen { return }
 
@@ -675,13 +675,13 @@ extension Nook {
     }
 
     /// Hide the chrome and tear the window down. Runs as a tracked transition under
-    /// ``runTransition(_:)`` — `generation` is the token it claimed synchronously.
+    /// ``runTransition(_:)`` - `generation` is the token it claimed synchronously.
     ///
     /// Because the hide now lives fully inside the generation system, every step
     /// re-checks ``isCurrent(_:)`` after each suspension point: a newer transition
     /// (a hover-grow, a drag auto-expand, a host `expand`) bumps the generation and
-    /// cancels this task via `runTransition`, so the teardown — `keepVisible` poll,
-    /// intermediate-hide dwell, `fadeOutWindow`, `deinitializeWindow` — bails before it
+    /// cancels this task via `runTransition`, so the teardown - `keepVisible` poll,
+    /// intermediate-hide dwell, `fadeOutWindow`, `deinitializeWindow` - bails before it
     /// can deinit a window the newer transition has already claimed. Previously this
     /// teardown ran in an untracked `closePanelTask` outside the generation system, so a
     /// hover-grow racing it could have the window deinit'd out from under a
@@ -689,14 +689,14 @@ extension Nook {
     ///
     /// `.keepVisible` still defers the hide until the cursor leaves the panel, but the
     /// poll is now part of this awaited transition rather than a recursively-spawned
-    /// untracked task — an awaited `hide()` always resolves: cursor leaves, supersession,
+    /// untracked task - an awaited `hide()` always resolves: cursor leaves, supersession,
     /// task cancellation, or already-hidden.
     func _hide(generation: Int) async {
         // Superseded before this task even started running.
         guard isCurrent(generation) else { return }
         guard state != .hidden else { return }
 
-        // `.keepVisible` defers an explicit hide until the cursor leaves the panel — we
+        // `.keepVisible` defers an explicit hide until the cursor leaves the panel - we
         // don't yank the surface out from under an active hover. Poll inline; bail if a
         // newer transition supersedes us, or if hover behavior stops requesting deferral.
         if hoverBehavior.contains(.keepVisible), isHovering {
@@ -705,7 +705,7 @@ extension Nook {
                 try? await Task.sleep(for: Self.keepVisiblePollInterval)
             }
             // Superseded (or cancelled) while waiting for the cursor to leave: a newer
-            // transition owns the surface now — do not tear its window down.
+            // transition owns the surface now - do not tear its window down.
             guard isCurrent(generation), !Task.isCancelled else { return }
             // A superseded-then-restored race could have left us already hidden.
             guard state != .hidden else { return }
@@ -717,7 +717,7 @@ extension Nook {
         }
 
         try? await Task.sleep(for: intermediateHideDuration)
-        // A newer transition took over across the close-animation dwell — it owns the
+        // A newer transition took over across the close-animation dwell - it owns the
         // window now, so skip the teardown entirely.
         guard isCurrent(generation), !Task.isCancelled else { return }
 
@@ -772,13 +772,13 @@ extension Nook {
         max(transitionConfiguration.animationDuration ?? Self.defaultAnimationDuration, 0)
     }
 
-    /// Settle allowance after a fresh open animation (`.hidden` → visible) before an
+    /// Settle allowance after a fresh open animation (`.hidden` -> visible) before an
     /// awaited `expand()`/`compact()` returns.
     ///
     /// SwiftUI's `Animation` exposes no portable duration accessor, so the surface cannot
     /// time the chrome's visible arrival from the animation itself. Instead the
     /// settle delay is derived from the *configured* animation duration
-    /// (``settleAnimationDuration``) plus a fixed cushion for the window-show fade — so
+    /// (``settleAnimationDuration``) plus a fixed cushion for the window-show fade - so
     /// the await contract holds whether the host keeps the default curves or supplies a
     /// slower custom animation. Sized to match the previous 550 ms constant at the
     /// default 0.4 s duration.
@@ -797,7 +797,7 @@ extension Nook {
 
     /// Dwell at `.hidden` between a close animation and the following conversion (or
     /// teardown), when intermediate hides are not skipped. A partial dwell of the
-    /// closing animation — the chrome need not be fully gone before the next phase
+    /// closing animation - the chrome need not be fully gone before the next phase
     /// starts. Sized to match the previous 250 ms constant at the default 0.4 s duration.
     var intermediateHideDuration: Duration {
         .seconds(settleAnimationDuration * 0.625)
@@ -861,7 +861,7 @@ private extension Nook {
         // Two modifiers used to live on a `NookContentView` shim: a full-bleed
         // top-anchored frame and a conversion animation on hover. Inlining the
         // shim removes a one-line passthrough that earned its keep only as a
-        // named type — `NSHostingView` is the only consumer.
+        // named type - `NSHostingView` is the only consumer.
         let rootView = NookView(nook: self)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .animation(effectiveConversionAnimation, value: isHovering)
@@ -923,7 +923,7 @@ private extension Nook {
     }
 
     /// Show with the hosting layer starting at opacity 0, then animate to 1. The window itself
-    /// is at full alpha — only the SwiftUI content fades in, masking any first-frame layout pop.
+    /// is at full alpha - only the SwiftUI content fades in, masking any first-frame layout pop.
     func showWindow() {
         guard let window = windowController?.window else { return }
 
@@ -951,7 +951,7 @@ private extension Nook {
 }
 
 // The drag-session state machine and `NookDragDestination` conformance live in
-// `Internal/Nook+Drag.swift` — kept out of this file so Nook.swift stays focused
+// `Internal/Nook+Drag.swift` - kept out of this file so Nook.swift stays focused
 // on lifecycle/transition concerns. The stored `dragSession` property is declared
 // above (on `Nook` itself); the surrounding state machine and the destination
 // conformance are the extracted pieces.

--- a/Sources/NookSurface/NookBackdrop.swift
+++ b/Sources/NookSurface/NookBackdrop.swift
@@ -12,14 +12,14 @@ import SwiftUI
 /// Three intentionally disjoint cases:
 ///
 /// - ``vibrancy(_:)`` paints an `NSVisualEffectView` material with an optional darken
-///   pass on top — the default frosted look, used when translucency is allowed.
-/// - ``solid(_:)`` paints a flat opaque fill — used for `.solid` chrome styles and
+///   pass on top - the default frosted look, used when translucency is allowed.
+/// - ``solid(_:)`` paints a flat opaque fill - used for `.solid` chrome styles and
 ///   whenever Reduce Transparency is on, where `NSVisualEffectView` is avoided.
 /// - ``liquidGlass(_:)`` paints Apple's Liquid Glass material (macOS 26+), falling back
 ///   to a layered material-plus-specular-rim approximation on earlier systems.
 ///
 /// These are *modes*, not flags. A caller picks one and supplies only the parameters
-/// that mode needs — no more eleven-field configuration struct where half the fields
+/// that mode needs - no more eleven-field configuration struct where half the fields
 /// are dead per branch.
 ///
 /// Extending to e.g. `.gradient(Gradient)` later is one new case and one new view
@@ -30,7 +30,7 @@ public enum NookBackdrop: Equatable, Sendable {
     case vibrancy(Vibrancy)
 
     /// Flat opaque fill. Use this for `.solid` chrome styles and when Reduce
-    /// Transparency is on — it avoids `NSVisualEffectView` entirely.
+    /// Transparency is on - it avoids `NSVisualEffectView` entirely.
     case solid(Color)
 
     /// Liquid Glass: the macOS 26 Tahoe glass material when available, an approximation
@@ -67,7 +67,7 @@ public enum NookBackdrop: Equatable, Sendable {
     /// Liquid Glass parameters. The same knobs drive both render paths: on macOS 26+
     /// they configure Apple's real glass material; on macOS 15-25 they drive the
     /// layered approximation. A host can build one directly and return it from a
-    /// ``NookChromeBehavior`` backdrop resolver to paint brand-tinted glass — that
+    /// ``NookChromeBehavior`` backdrop resolver to paint brand-tinted glass - that
     /// closure, not this struct, is where the "more customizable than off-the-shelf"
     /// flexibility lives.
     public struct LiquidGlass: Equatable, Sendable {
@@ -86,7 +86,7 @@ public enum NookBackdrop: Equatable, Sendable {
         public var highlightStrength: CGFloat
 
         /// Legibility pass composited under chrome content, expressed as a gradient the
-        /// caller fully owns — flat, bottom-weighted, top-weighted, banded, multi-stop,
+        /// caller fully owns - flat, bottom-weighted, top-weighted, banded, multi-stop,
         /// any direction, any color. `nil` leaves the glass pristine. The surface renders
         /// exactly this and imposes nothing of its own, so a coder building on OpenNook is
         /// never boxed into the framework's idea of the gradient; the framework's default
@@ -118,7 +118,7 @@ public enum NookBackdrop: Equatable, Sendable {
             /// Where the gradient begins. Defaults to the top edge.
             public var startPoint: UnitPoint
 
-            /// Where the gradient ends. Defaults to the bottom edge — so a two-stop
+            /// Where the gradient ends. Defaults to the bottom edge - so a two-stop
             /// gradient runs top-to-bottom, the common "glassier toward the bottom" case.
             public var endPoint: UnitPoint
 
@@ -132,14 +132,14 @@ public enum NookBackdrop: Equatable, Sendable {
                 self.endPoint = endPoint
             }
 
-            /// A flat, uniform shading of one color — no gradient falloff.
+            /// A flat, uniform shading of one color - no gradient falloff.
             public static func uniform(_ color: Color) -> Shading {
                 Shading(gradient: Gradient(colors: [color, color]))
             }
         }
     }
 
-    /// The default backdrop — a pure black solid, matching the menu-bar notch chrome
+    /// The default backdrop - a pure black solid, matching the menu-bar notch chrome
     /// when no other treatment is wanted. Equivalent to the historical
     /// `NookBackdropConfiguration.solidBlack`; rendering is byte-identical.
     public static let solidBlack = NookBackdrop.solid(.black)

--- a/Sources/NookSurface/NookContentInsets.swift
+++ b/Sources/NookSurface/NookContentInsets.swift
@@ -35,7 +35,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// The values represent residual clearance — the chrome's own pre-applied
+/// The values represent residual clearance - the chrome's own pre-applied
 /// paddings (the horizontal inset by `topCornerRadius`, the small bottom
 /// safe-area strip) are already subtracted, so an inset of `0` means "the
 /// chrome's geometry doesn't intrude into your frame on that edge."
@@ -62,7 +62,7 @@ public struct NookContentInsets: Equatable, Sendable {
         self.trailing = trailing
     }
 
-    /// No clearance needed — the default before the chrome computes its
+    /// No clearance needed - the default before the chrome computes its
     /// geometry (and the value reported in `.compact`/`.hidden`, where no host
     /// expanded content is laid out).
     public static let zero = NookContentInsets()
@@ -88,7 +88,7 @@ extension NookContentInsets {
     /// Each residual is `curve − chromePrePad`, floored at zero: the curve intrudes
     /// into the host frame by however much it exceeds the chrome's own inset on that
     /// edge. Tightening `chromeSafeAreaInsets.bottom` therefore *raises* the reported
-    /// bottom residual — with less pre-padding, a host pinning content into a bottom
+    /// bottom residual - with less pre-padding, a host pinning content into a bottom
     /// *corner* must inset more itself to clear the curve. Horizontally-centered
     /// content stays clear of the corners and can ignore the residual.
     static func expanded(

--- a/Sources/NookSurface/NookControllable.swift
+++ b/Sources/NookSurface/NookControllable.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -11,7 +11,7 @@ import AppKit
 /// Async surface for driving any nook-shaped presenter (today: ``Nook``).
 ///
 /// `expand`/`compact` take an optional target screen. Passing `nil` lets the
-/// presenter resolve the screen itself — see ``Nook/screenProvider`` — which is
+/// presenter resolve the screen itself - see ``Nook/screenProvider`` - which is
 /// how multi-display host apps express a persisted display preference without
 /// threading an `NSScreen` through every call site.
 @MainActor

--- a/Sources/NookSurface/NookFeedback.swift
+++ b/Sources/NookSurface/NookFeedback.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -8,14 +8,14 @@
 
 import Foundation
 
-/// A peripheral cue the chrome can play along its perimeter — a one-shot signal the user
+/// A peripheral cue the chrome can play along its perimeter - a one-shot signal the user
 /// catches at the edge of vision without having to look directly at the notch.
 ///
 /// Trigger one with ``Nook/playFeedback(_:tint:duration:repeats:)``. Modeled as an enum so
 /// new effects can be added without reshaping call sites.
 public enum NookFeedback: String, CaseIterable, Codable, Sendable {
     /// A bright band sweeping the chrome's perimeter from the leading to the trailing edge.
-    /// The most legible peripheral cue against the dark notch arch — a moving highlight that
+    /// The most legible peripheral cue against the dark notch arch - a moving highlight that
     /// grazes the eye without reading as a notification badge.
     case shimmer
 

--- a/Sources/NookSurface/NookHoverBehavior.swift
+++ b/Sources/NookSurface/NookHoverBehavior.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt

--- a/Sources/NookSurface/NookPresentation.swift
+++ b/Sources/NookSurface/NookPresentation.swift
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 Glendon Chin — OpenNook
+// Copyright (c) 2026 Glendon Chin - OpenNook
 //
 // Part of the MIT-licensed NookSurface module.
 // Module license: /LICENSE-MIT-NOOKSURFACE
@@ -8,17 +8,17 @@ import Foundation
 
 /// How the Nook chrome presents itself relative to the screen.
 ///
-/// A notch app's whole premise is the physical notch — but plenty of Macs don't have
+/// A notch app's whole premise is the physical notch - but plenty of Macs don't have
 /// one (a Mac mini/Studio on an external display, pre-2021 MacBooks, any desktop
 /// display). ``floating`` is the fallback: instead of an eared shape fused to the
 /// menu-bar notch, the chrome renders as a free-floating rounded panel just below the
 /// menu bar.
 ///
-/// - ``auto`` — notch layout on a notched display, floating layout otherwise. The
+/// - ``auto`` - notch layout on a notched display, floating layout otherwise. The
 ///   default, and the right choice for almost every app.
-/// - ``notch`` — always the notch layout, even on a display with no notch (the
+/// - ``notch`` - always the notch layout, even on a display with no notch (the
 ///   eared shape then hangs from the bare menu bar; mostly useful for testing).
-/// - ``floating`` — always the floating layout, even on a notched display.
+/// - ``floating`` - always the floating layout, even on a notched display.
 public enum NookPresentation: String, Codable, Sendable, CaseIterable, Equatable {
     case auto
     case notch
@@ -35,7 +35,7 @@ public enum NookPresentation: String, Codable, Sendable, CaseIterable, Equatable
     }
 }
 
-/// The resolved layout the surface actually renders — the concrete outcome of a
+/// The resolved layout the surface actually renders - the concrete outcome of a
 /// ``NookPresentation`` against a specific screen. Internal: callers express intent
 /// through ``NookPresentation``; the surface picks the form.
 enum NookChromeForm: Equatable {

--- a/Sources/NookSurface/NookState.swift
+++ b/Sources/NookSurface/NookState.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt

--- a/Sources/NookSurface/NookStyle.swift
+++ b/Sources/NookSurface/NookStyle.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -42,7 +42,7 @@ public struct NookStyle: Equatable, Sendable {
 
     /// Safe-area strip the chrome reserves around the host's expanded content, applied
     /// as `.safeAreaInset` on each edge of the expanded surface. This is the chrome's
-    /// own clearance — distinct from any padding a host wrapper (e.g. `NookExpandedView`)
+    /// own clearance - distinct from any padding a host wrapper (e.g. `NookExpandedView`)
     /// adds inside it.
     ///
     /// The default (``standardExpandedContentInsets``) reproduces the historical fixed
@@ -50,7 +50,7 @@ public struct NookStyle: Equatable, Sendable {
     /// so the published ``NookContentInsets/top`` reports the full `topCornerRadius`) and
     /// 8 on the other three edges.
     ///
-    /// Tightening `bottom` lets content sit closer to the rounded bottom — useful when a
+    /// Tightening `bottom` lets content sit closer to the rounded bottom - useful when a
     /// host wants to reclaim the dead band below its last row. Because the bottom corners
     /// curve inward by `bottomCornerRadius`, content pinned into a *bottom corner* will
     /// intersect that curve once `bottom` drops below it; the published
@@ -86,6 +86,6 @@ public struct NookStyle: Equatable, Sendable {
     public var openingAnimation: Animation { .bouncy(duration: 0.4) }
     /// The surface's built-in collapse animation. See ``openingAnimation``.
     public var closingAnimation: Animation { .smooth(duration: 0.4) }
-    /// The surface's built-in compact↔expanded animation. See ``openingAnimation``.
+    /// The surface's built-in compact<->expanded animation. See ``openingAnimation``.
     public var conversionAnimation: Animation { .snappy(duration: 0.4) }
 }

--- a/Sources/NookSurface/NookSurfaceAmbience.swift
+++ b/Sources/NookSurface/NookSurfaceAmbience.swift
@@ -22,7 +22,7 @@ public struct NookAmbientColorPreferenceKey: PreferenceKey {
 }
 
 /// A top-to-bottom wash rendered behind expanded surface content when a `NookAmbientColorPreferenceKey`
-/// value is present. Purely decorative and non-interactive — the engine draws it but does
+/// value is present. Purely decorative and non-interactive - the engine draws it but does
 /// not interpret it.
 public struct NookAmbientColorBackground: View {
     let color: Color

--- a/Sources/NookSurface/NookTransitionConfiguration.swift
+++ b/Sources/NookSurface/NookTransitionConfiguration.swift
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2025 Kai Azim — DynamicNotchKit (original)
-// Copyright (c) 2026 Glendon Chin — OpenNook modifications
+// Copyright (c) 2025 Kai Azim - DynamicNotchKit (original)
+// Copyright (c) 2026 Glendon Chin - OpenNook modifications
 //
 // Licensed under the MIT License.
 // Original kit license: /ThirdPartyLicenses/DynamicNotchKit.txt
@@ -10,13 +10,13 @@ import SwiftUI
 
 /// Per-instance overrides for the surface's animation curves. Nil values fall back to ``NookStyle`` defaults.
 public struct NookTransitionConfiguration: Sendable {
-    /// Hidden → expanded / hidden → compact.
+    /// Hidden -> expanded / hidden -> compact.
     public var openingAnimation: Animation?
-    /// Expanded → hidden / compact → hidden.
+    /// Expanded -> hidden / compact -> hidden.
     public var closingAnimation: Animation?
-    /// Compact ↔ expanded.
+    /// Compact <-> expanded.
     public var conversionAnimation: Animation?
-    /// When `true`, compact↔expanded skips the intermediate hide-and-show.
+    /// When `true`, compact<->expanded skips the intermediate hide-and-show.
     public var skipIntermediateHides: Bool
 
     /// Longest duration, in seconds, of any animation supplied above.

--- a/Tests/NookComponentsTests/NookActivityQueueTests.swift
+++ b/Tests/NookComponentsTests/NookActivityQueueTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @testable import NookComponents
 import NookKit
 
-/// A `NookSurfacePresenting` stand-in — no real window, fully controllable engagement.
+/// A `NookSurfacePresenting` stand-in - no real window, fully controllable engagement.
 @MainActor
 private final class FakePresenter: NookSurfacePresenting {
     private let engagement = CurrentValueSubject<Bool, Never>(false)
@@ -19,7 +19,7 @@ private final class FakePresenter: NookSurfacePresenting {
     private(set) var endCount = 0
     private var nextToken = 0
 
-    /// When > 0, the next N `beginTransientPresentation(_:)` calls reject the takeover —
+    /// When > 0, the next N `beginTransientPresentation(_:)` calls reject the takeover - 
     /// simulating the user grabbing the surface in the pre-takeover race window.
     var rejectNextBegins = 0
 
@@ -93,7 +93,7 @@ final class NookActivityQueueTests: XCTestCase {
 
     @MainActor
     func testCoalescingKeyKeepsLatest() {
-        // No presenter bound — the queue holds activities without draining.
+        // No presenter bound - the queue holds activities without draining.
         let queue = instantQueue()
 
         queue.enqueue(NookActivity(coalescingKey: "sync", title: "First"))
@@ -133,13 +133,13 @@ final class NookActivityQueueTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(50))
         XCTAssertEqual(presenter.beginCount, 0, "must not present while the user is engaged")
 
-        // Cooperative suspend: the drain task is NOT cancelled — it exits on its own
+        // Cooperative suspend: the drain task is NOT cancelled - it exits on its own
         // when the engagement-wait next polls (≤200ms) or when the current dwell ends.
         queue.suspend()
         await queue.drainTask?.value
         XCTAssertNil(queue.drainTask, "drain task cleared itself after the cooperative exit")
 
-        // Resume while still engaged — a fresh drain task spawns and re-parks in the
+        // Resume while still engaged - a fresh drain task spawns and re-parks in the
         // engagement wait. Disengage, then drain to completion.
         queue.resume()
         try await Task.sleep(for: .milliseconds(50))
@@ -153,7 +153,7 @@ final class NookActivityQueueTests: XCTestCase {
     }
 
     /// Regression: a `suspend()` issued *while an activity is dwelling on screen* must
-    /// let that dwell finish and the claim release normally — not cancel mid-dwell and
+    /// let that dwell finish and the claim release normally - not cancel mid-dwell and
     /// strand the arbiter token. The contract advertised by `suspend()` says the
     /// current activity finishes; this pins it.
     @MainActor
@@ -171,7 +171,7 @@ final class NookActivityQueueTests: XCTestCase {
         XCTAssertNotNil(queue.current)
 
         queue.suspend()
-        // suspend() must NOT cancel the drain task — the current dwell must complete.
+        // suspend() must NOT cancel the drain task - the current dwell must complete.
         await queue.drainTask?.value
 
         XCTAssertEqual(presenter.endCount, 1, "in-flight activity released its claim normally")
@@ -219,7 +219,7 @@ final class NookActivityQueueTests: XCTestCase {
             .sink { presented.append($0) }
 
         // A is enqueued first and is the one whose first takeover gets rejected.
-        // B is enqueued *before* the retry — at the same priority. FIFO-within-priority
+        // B is enqueued *before* the retry - at the same priority. FIFO-within-priority
         // means B presents before A's retry.
         queue.enqueue(NookActivity(priority: .normal, title: "A"))
         queue.enqueue(NookActivity(priority: .normal, title: "B"))
@@ -275,7 +275,7 @@ final class NookActivityQueueTests: XCTestCase {
         XCTAssertTrue(queue.isSuspended)
     }
 
-    /// `quiesce()` is idempotent and safe on an idle queue — a second call is a no-op.
+    /// `quiesce()` is idempotent and safe on an idle queue - a second call is a no-op.
     @MainActor
     func testQuiesceIsIdempotent() async {
         let queue = instantQueue()

--- a/Tests/NookComponentsTests/ShelfDragSourceTests.swift
+++ b/Tests/NookComponentsTests/ShelfDragSourceTests.swift
@@ -9,7 +9,7 @@ import UniformTypeIdentifiers
 import XCTest
 @testable import NookComponents
 
-/// Pins the file-promise drag-out plumbing — the bookmark-resolve + scoped-copy path
+/// Pins the file-promise drag-out plumbing - the bookmark-resolve + scoped-copy path
 /// the receiver eventually triggers. The receiver-side trigger itself (AppKit calling
 /// the registered `NSItemProvider` representation) is an integration concern out of
 /// unit-test reach; what we CAN test deterministically is the write closure.
@@ -46,7 +46,7 @@ final class ShelfDragSourceTests: XCTestCase {
         XCTAssertEqual(written, Data("OPENNOOK".utf8))
     }
 
-    /// An unresolvable bookmark produces `ShelfDragError.unresolvable` — the receiver
+    /// An unresolvable bookmark produces `ShelfDragError.unresolvable` - the receiver
     /// gets a meaningful error rather than a silent failure or a crash.
     func testWriteShelfItemReportsErrorWhenSourceUnresolvable() throws {
         let stage = try makeTempStage()
@@ -122,7 +122,7 @@ final class ShelfDragSourceTests: XCTestCase {
                     // AppKit copies the file out before calling the completion; the URL
                     // here is a coordinator-owned URL pointing at the OS-managed copy.
                     // What we care about is that the call resolves with a URL and no
-                    // error — i.e. the staging path was created and the copy succeeded.
+                    // error - i.e. the staging path was created and the copy succeeded.
                     if error != nil {
                         continuation.resume(returning: nil)
                     } else {

--- a/Tests/NookComponentsTests/ShelfStoreTests.swift
+++ b/Tests/NookComponentsTests/ShelfStoreTests.swift
@@ -93,7 +93,7 @@ final class ShelfStoreTests: XCTestCase {
         store.accept([kept, deleted])
         XCTAssertEqual(store.items.count, 2)
 
-        // With a surviving sibling, access is clearly working — so the one genuinely
+        // With a surviving sibling, access is clearly working - so the one genuinely
         // missing file should be purged.
         try FileManager.default.removeItem(at: deleted)
         store.purgeMissing()
@@ -101,8 +101,8 @@ final class ShelfStoreTests: XCTestCase {
         XCTAssertEqual(store.items.first?.resolveURL()?.standardizedFileURL, kept.standardizedFileURL)
     }
 
-    /// Regression: when *every* item fails to resolve — indistinguishable from a
-    /// sandboxed host that lost its file-access grant — the shelf must be preserved,
+    /// Regression: when *every* item fails to resolve - indistinguishable from a
+    /// sandboxed host that lost its file-access grant - the shelf must be preserved,
     /// not silently wiped.
     func testPurgeMissingPreservesShelfOnSystemicFailure() throws {
         let (store, _, _) = freshStore()
@@ -119,7 +119,7 @@ final class ShelfStoreTests: XCTestCase {
     }
 
     /// The consolidated `init` reconcile (load + heal + purge in one pass) must purge an
-    /// individually-deleted file on launch, exactly as `purgeMissing()` does — proving
+    /// individually-deleted file on launch, exactly as `purgeMissing()` does - proving
     /// the single-pass consolidation preserves the per-item purge behaviour.
     func testInitReconcilePurgesIndividualDeletedFile() throws {
         let defaults = UserDefaults(suiteName: "nook.test.\(UUID().uuidString)")!
@@ -188,7 +188,7 @@ final class ShelfStoreTests: XCTestCase {
             displayName: "ghost",
             fileExtension: "txt",
             addedAt: Date(),
-            bookmark: Data(repeating: 0xff, count: 32),  // garbage — will not resolve
+            bookmark: Data(repeating: 0xff, count: 32),  // garbage - will not resolve
             typeIdentifier: "public.plain-text",
             bookmarkKind: .nonScoped
         )
@@ -230,14 +230,14 @@ final class ShelfStoreTests: XCTestCase {
     }
 
     /// Items persisted before the `bookmarkKind` field existed decode as `.unknown`
-    /// and are treated exactly like `.nonScoped` for purge — preserved on failure.
+    /// and are treated exactly like `.nonScoped` for purge - preserved on failure.
     func testUnknownKindTreatedAsNonScopedForPurge() throws {
         let defaults = UserDefaults(suiteName: "nook.test.\(UUID().uuidString)")!
         let key = "items"
         let alive = try makeTempFile()
         defer { try? FileManager.default.removeItem(at: alive) }
 
-        // Emit JSON missing the `bookmarkKind` key — the shape an older build wrote.
+        // Emit JSON missing the `bookmarkKind` key - the shape an older build wrote.
         let aliveItem = ShelfItem.make(from: alive)!
         let aliveDict: [String: Any] = [
             "id": aliveItem.id.uuidString,
@@ -256,7 +256,7 @@ final class ShelfStoreTests: XCTestCase {
             "typeIdentifier": "public.plain-text"
         ]
         // We avoid JSONSerialization here because JSONEncoder writes Dates and Data
-        // with specific encodings — emit those by hand to match its defaults exactly.
+        // with specific encodings - emit those by hand to match its defaults exactly.
         let json = """
         [
           {"id":"\(aliveItem.id.uuidString)",

--- a/Tests/NookComponentsTests/SystemVolumeObserverTests.swift
+++ b/Tests/NookComponentsTests/SystemVolumeObserverTests.swift
@@ -9,12 +9,12 @@ import CoreAudio
 import XCTest
 @testable import NookComponents
 
-/// A fully controllable ``VolumeReading`` — no live audio device. Lets the tests drive
+/// A fully controllable ``VolumeReading`` - no live audio device. Lets the tests drive
 /// the default-device, volume, and mute reads deterministically.
 ///
 /// `@unchecked Sendable` so a test can mutate it after the observer has captured it.
 /// That is sound here: the observer only reads through it on the main actor, and the
-/// tests are `@MainActor` too — there is no real concurrency.
+/// tests are `@MainActor` too - there is no real concurrency.
 private final class FakeVolumeReader: VolumeReading, @unchecked Sendable {
     var device: AudioDeviceID? = AudioDeviceID(1)
     var volume: Double? = 0.5
@@ -30,7 +30,7 @@ final class SystemVolumeObserverTests: XCTestCase {
     // MARK: - resolveVolumeFallback (pure: main-element vs per-channel average)
 
     func testFallbackPrefersMainElementScalar() {
-        // A main-element scalar wins outright — channel scalars are ignored.
+        // A main-element scalar wins outright - channel scalars are ignored.
         XCTAssertEqual(resolveVolumeFallback(mainScalar: 0.4, channelScalars: [0.1, 0.9]), 0.4)
     }
 
@@ -44,7 +44,7 @@ final class SystemVolumeObserverTests: XCTestCase {
     }
 
     func testFallbackReturnsNilWhenNothingAvailable() {
-        // Neither a main scalar nor any channel scalar — unreadable.
+        // Neither a main scalar nor any channel scalar - unreadable.
         XCTAssertNil(resolveVolumeFallback(mainScalar: nil, channelScalars: []))
     }
 
@@ -71,7 +71,7 @@ final class SystemVolumeObserverTests: XCTestCase {
     @MainActor
     func testObserverClampsVolumeIntoUnitRange() {
         // A reader reporting an out-of-range value (a quirky device, a stale read) must
-        // not leak past `0...1` — the observer clamps before publishing.
+        // not leak past `0...1` - the observer clamps before publishing.
         let high = FakeVolumeReader()
         high.volume = 1.7
         XCTAssertEqual(SystemVolumeObserver(reader: high).volume, 1.0)
@@ -83,7 +83,7 @@ final class SystemVolumeObserverTests: XCTestCase {
 
     @MainActor
     func testObserverReportsZeroWhenNoDefaultDevice() {
-        // No default output device available — the observer reports a silent, unmuted
+        // No default output device available - the observer reports a silent, unmuted
         // baseline rather than stale state.
         let reader = FakeVolumeReader()
         reader.device = nil
@@ -98,7 +98,7 @@ final class SystemVolumeObserverTests: XCTestCase {
     @MainActor
     func testObserverRebindsToNewDefaultDevice() {
         // Bind to a device with a known level, then swap the default device out from
-        // under the observer and trigger a rebind — it must follow the new device.
+        // under the observer and trigger a rebind - it must follow the new device.
         let reader = FakeVolumeReader()
         reader.device = AudioDeviceID(1)
         reader.volume = 0.25
@@ -133,7 +133,7 @@ final class SystemVolumeObserverTests: XCTestCase {
         XCTAssertEqual(observer.removedListenerCountForTesting, 0)
 
         // A rebind must remove the two device listeners and re-add a fresh pair, so
-        // adds increase by 2 and removes by 2 — net no leak.
+        // adds increase by 2 and removes by 2 - net no leak.
         reader.device = AudioDeviceID(2)
         observer.rebindForTesting()
         XCTAssertEqual(observer.addedListenerCountForTesting, 5)

--- a/Tests/NookKitTests/AppCoordinatorTests.swift
+++ b/Tests/NookKitTests/AppCoordinatorTests.swift
@@ -18,7 +18,7 @@ final class AppCoordinatorTests: XCTestCase {
         private(set) var switchAwayCount = 0
         private(set) var quiesceWork: (@MainActor () async -> Void)?
 
-        /// Where this module records its own `onExpand` firings — shared with the test.
+        /// Where this module records its own `onExpand` firings - shared with the test.
         let expandLog: ExpandLog
 
         init(id: String, expandLog: ExpandLog, quiesceWork: (@MainActor () async -> Void)? = nil) {
@@ -102,7 +102,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     /// A switch quiesces the outgoing module. With the reordered switch, the quiesce
-    /// runs off the lifecycle chain — `drainSwitchTailsForTesting()` joins it.
+    /// runs off the lifecycle chain - `drainSwitchTailsForTesting()` joins it.
     func testSwitchQuiescesOutgoingModule() async {
         let log = ExpandLog()
         let a = SpyModule(id: "A", expandLog: log)
@@ -171,7 +171,7 @@ final class AppCoordinatorTests: XCTestCase {
     /// surface transition behind it.
     func testSwitchDoesNotWedgeOnHangingPrepareForSwitchAway() async {
         let log = ExpandLog()
-        // A's quiesce parks forever — simulating a misbehaving module.
+        // A's quiesce parks forever - simulating a misbehaving module.
         let a = SpyModule(id: "A", expandLog: log, quiesceWork: {
             try? await Task.sleep(for: .seconds(60))
         })
@@ -193,7 +193,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     /// `registerGlobalHotkey` records its outcome on the durable failure channel.
-    /// A successful registration leaves no `"toggle"` failure entry, and — critically —
+    /// A successful registration leaves no `"toggle"` failure entry, and - critically - 
     /// a pre-existing failure entry is cleared once a registration succeeds.
     func testRegisterGlobalHotkeyClearsFailureOnSuccess() {
         let log = ExpandLog()
@@ -243,12 +243,12 @@ final class AppCoordinatorTests: XCTestCase {
     /// the runloop the way these sinks are scheduled on.
     private func drainAndPump(_ coordinator: AppCoordinator) async {
         await coordinator.drainLifecycleForTesting()
-        try? await Task.sleep(nanoseconds: 30_000_000)  // 30 ms — generous on CI
+        try? await Task.sleep(nanoseconds: 30_000_000)  // 30 ms - generous on CI
     }
 
     /// REGRESSION: the arbiter's own `expand()` must NOT trip `isUserEngaged`. Before
     /// the fix, `isUserEngaged` read `appState.isNookVisible`, which mirrored the
-    /// surface and flipped `true` as soon as the arbiter expanded — silently disabling
+    /// surface and flipped `true` as soon as the arbiter expanded - silently disabling
     /// all subsequent preemption. After the fix, engagement reads from explicit user
     /// intent, so the arbiter's expand leaves it `false`.
     func testArbiterExpandDoesNotMarkUserEngaged() async {
@@ -283,7 +283,7 @@ final class AppCoordinatorTests: XCTestCase {
             NookSurfaceClaim(moduleID: "A", priority: .normal)
         )
         XCTAssertNotNil(normal)
-        await drainAndPump(coordinator)  // let the mirror flip — this is what hid the bug
+        await drainAndPump(coordinator)  // let the mirror flip - this is what hid the bug
 
         let urgent = await coordinator.beginTransientPresentation(
             NookSurfaceClaim(moduleID: "A", priority: .urgent)
@@ -332,7 +332,7 @@ final class AppCoordinatorTests: XCTestCase {
 
     /// If the surface collapses independently (hover-exit auto-compact, simulated here
     /// by a direct `compact(on:)`), the `bindSurfaceVisibility` sink clears the user-
-    /// open intent — so the arbiter is willing to grant the next claim.
+    /// open intent - so the arbiter is willing to grant the next claim.
     func testHoverExitAutoCompactClearsUserOpenIntent() async {
         let log = ExpandLog()
         let a = SpyModule(id: "A", expandLog: log)
@@ -357,7 +357,7 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertNotNil(token, "a transient claim is grantable after the user's nook collapsed")
     }
 
-    /// Hover engagement counts even when the user did not open the surface — i.e.,
+    /// Hover engagement counts even when the user did not open the surface - i.e.,
     /// `userInitiatedOpen` is unset but `isHovering` is true.
     func testHoveringBlocksTransientEvenWithoutUserOpen() async {
         let log = ExpandLog()
@@ -416,13 +416,13 @@ final class AppCoordinatorTests: XCTestCase {
         surface.isHovering = true
         XCTAssertTrue(coordinator.isUserEngaged)
 
-        // The surface is still expanded — the arbiter does not force-end mid-claim.
+        // The surface is still expanded - the arbiter does not force-end mid-claim.
         XCTAssertEqual(
             surface.state, .expanded,
             "mid-claim engagement does NOT preempt — the presenter must yield itself"
         )
 
-        // A NEW claim, however, is denied — engagement gates `begin`.
+        // A NEW claim, however, is denied - engagement gates `begin`.
         let denied = await coordinator.beginTransientPresentation(NookSurfaceClaim(moduleID: "A"))
         XCTAssertNil(denied, "a new claim is denied while the user is now engaged")
 
@@ -441,7 +441,7 @@ final class AppCoordinatorTests: XCTestCase {
     /// Regression: switching to a module whose `topBar.showsSettings == false` must drop
     /// any stranded `viewMode == .settings`. Without this, the chrome's top bar reads a
     /// settings-mode viewMode and renders a back-chevron at a Settings screen that
-    /// `NookExpandedView` correctly refuses to mount — the user sees a phantom nav target.
+    /// `NookExpandedView` correctly refuses to mount - the user sees a phantom nav target.
     func testSwitchToModuleWithSettingsDisabledClearsStrandedSettingsViewMode() async {
         final class SettingsHidingModule: NookModule {
             let descriptor: NookModuleDescriptor
@@ -472,7 +472,7 @@ final class AppCoordinatorTests: XCTestCase {
             surface: surface
         )
 
-        // User opens Settings while on A — viewMode strands to .settings.
+        // User opens Settings while on A - viewMode strands to .settings.
         coordinator.appState.showSettings()
         XCTAssertEqual(coordinator.appState.viewMode, .settings)
 
@@ -487,7 +487,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     /// Counter: switching to a module that *also* allows Settings must NOT touch a
-    /// `.settings` viewMode. The fix is narrow — only clear when the incoming module
+    /// `.settings` viewMode. The fix is narrow - only clear when the incoming module
     /// disables the Settings screen.
     func testSwitchPreservesSettingsViewModeWhenIncomingModuleAllowsIt() async {
         let log = ExpandLog()
@@ -515,7 +515,7 @@ final class AppCoordinatorTests: XCTestCase {
     /// upstream emission separately, recording the registration outcome twice on the
     /// durable failure channel and minting two fresh Carbon ids per rebind. Mapping the
     /// combineLatest pair onto a `HotkeyRegistrationIntent` collapses the two emissions
-    /// onto one *intent change* (suspended → bound), and `removeDuplicates` then dedups
+    /// onto one *intent change* (suspended -> bound), and `removeDuplicates` then dedups
     /// transitional duplicates.
     func testHotkeyRebindFiresExactlyOneRegisterPerUserAction() async throws {
         let log = ExpandLog()
@@ -526,7 +526,7 @@ final class AppCoordinatorTests: XCTestCase {
         coordinator.bindHotkeyRegistration()  // install the sink
         let mintedAfterStart = coordinator.hotkeyController.carbonIDsMintedForTesting
 
-        // Open the recorder — intent maps to `.suspended`; sink unregisters (no mint).
+        // Open the recorder - intent maps to `.suspended`; sink unregisters (no mint).
         coordinator.appState.isRecordingHotkey = true
         try await Task.sleep(nanoseconds: 30_000_000)
         XCTAssertEqual(
@@ -535,7 +535,7 @@ final class AppCoordinatorTests: XCTestCase {
         )
 
         // User picks a new hotkey, then closes the recorder. Both publishes happen on
-        // the same runloop turn — the sink must fire exactly ONE register for the new
+        // the same runloop turn - the sink must fire exactly ONE register for the new
         // hotkey, not one per upstream @Published change.
         let newHotkey = NookHotkey(keyCode: 51, carbonModifiers: 4096 | 2048, keySymbol: "⌫")
         coordinator.appState.replaceHotkey(newHotkey)
@@ -551,7 +551,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     /// Recorder opened and then cancelled without changing the key collapses through
-    /// `.suspended` → `.bound(unchanged)` — exactly one restore registration after the
+    /// `.suspended` -> `.bound(unchanged)` - exactly one restore registration after the
     /// unregister.
     // MARK: - Cold-launch onCompact suppression
 
@@ -595,7 +595,7 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(counter.value, 0, "cold-launch compact did not fire host onCompact")
         XCTAssertEqual(surface.state, .compact, "but the surface IS compact")
 
-        // A subsequent user-driven compact fires it normally — the suppression is
+        // A subsequent user-driven compact fires it normally - the suppression is
         // strictly for the boot transition.
         await surface.expand(on: nil)
         await surface.compact(on: nil)
@@ -680,7 +680,7 @@ final class AppCoordinatorTests: XCTestCase {
     // MARK: - Presentation pinning
 
     /// A pin acquired through the host-wide ``NookPresentationPinning`` broker projects
-    /// onto `surface.staysExpandedOnHoverExit` — so a popover that moves the pointer out
+    /// onto `surface.staysExpandedOnHoverExit` - so a popover that moves the pointer out
     /// of the notch window no longer triggers the hover-exit auto-compact.
     func testPresentationPinFlipsStaysExpandedOnHoverExit() async {
         let log = ExpandLog()
@@ -717,7 +717,7 @@ final class AppCoordinatorTests: XCTestCase {
         let surface = FakeNookSurface()
         let coordinator = makeCoordinator(modules: [a], surface: surface)
 
-        // Neither hover nor user-open intent is set — but pinning *is* engagement.
+        // Neither hover nor user-open intent is set - but pinning *is* engagement.
         XCTAssertFalse(coordinator.isUserEngaged, "baseline: nothing engaging the surface")
 
         let handle = coordinator.presentationPinning.pin()
@@ -803,7 +803,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     /// When the user has `keepNookOpen` set, releasing the last pin must restore that
-    /// preference — not silently turn it off. The pin overrides the user preference
+    /// preference - not silently turn it off. The pin overrides the user preference
     /// upward (always pinned while presenting); release must return control to it.
     func testPinReleaseRestoresKeepNookOpenPreference() async {
         let log = ExpandLog()

--- a/Tests/NookKitTests/AppStateTests.swift
+++ b/Tests/NookKitTests/AppStateTests.swift
@@ -47,7 +47,7 @@ final class AppStateTests: XCTestCase {
         XCTAssertEqual(state.hotkeyRegistrationFailures["toggle"], failure)
     }
 
-    /// A hotkey-registration failure must survive a transient-status reset — unlike
+    /// A hotkey-registration failure must survive a transient-status reset - unlike
     /// `errorMessage`, it outlives a single nook session.
     func testHotkeyRegistrationFailureSurvivesTransientReset() {
         let state = AppState()
@@ -82,7 +82,7 @@ final class AppStateTests: XCTestCase {
         )
     }
 
-    /// Failures are tracked per registration id — one shortcut's failure never
+    /// Failures are tracked per registration id - one shortcut's failure never
     /// overwrites another's, and clearing one leaves the other intact.
     func testHotkeyRegistrationFailuresAreTrackedPerID() {
         let state = AppState()

--- a/Tests/NookKitTests/FakeNookSurface.swift
+++ b/Tests/NookKitTests/FakeNookSurface.swift
@@ -20,7 +20,7 @@ import SwiftUI
 @MainActor
 final class FakeNookSurface: NookSurfaceDriving {
     /// Every state this surface has transitioned *into*, in order. The constructor's
-    /// initial `.hidden` is not recorded — only transitions driven by the coordinator.
+    /// initial `.hidden` is not recorded - only transitions driven by the coordinator.
     private(set) var transitions: [NookState] = []
 
     private let stateSubject = CurrentValueSubject<NookState, Never>(.hidden)
@@ -68,7 +68,7 @@ final class FakeNookSurface: NookSurfaceDriving {
     var backdrop: NookBackdrop = .solidBlack
     var transitionConfiguration = NookTransitionConfiguration()
 
-    /// Mirrors the real surface's `hasLiveWindow` — tests flip this to drive the
+    /// Mirrors the real surface's `hasLiveWindow` - tests flip this to drive the
     /// coordinator's display-change-while-visible branch without mounting a real
     /// window.
     var hasLiveWindow: Bool = false
@@ -84,7 +84,7 @@ final class FakeNookSurface: NookSurfaceDriving {
         feedbackCount += 1
     }
 
-    /// Applies a state change, records it, and fires the matching lifecycle hook —
+    /// Applies a state change, records it, and fires the matching lifecycle hook - 
     /// mirroring the real surface, whose hooks fire on every distinct transition.
     private func transition(to newState: NookState) {
         guard newState != stateSubject.value else { return }

--- a/Tests/NookKitTests/HotkeyControllerTests.swift
+++ b/Tests/NookKitTests/HotkeyControllerTests.swift
@@ -12,13 +12,13 @@ import XCTest
 /// Bookkeeping coverage for ``HotkeyController``. The Carbon-level
 /// `RegisterEventHotKey` call may or may not succeed depending on the test
 /// environment (an XCTest binary often lacks a proper app context), but the
-/// controller's own dispatch table — what `register`/`unregister`/`unregisterAll`
-/// keep — is fully observable through the internal test seam and is what these
+/// controller's own dispatch table - what `register`/`unregister`/`unregisterAll`
+/// keep - is fully observable through the internal test seam and is what these
 /// tests pin. The Carbon-event delivery path itself is integration-tested by
 /// `AppCoordinatorTests`' real hotkey registration.
 @MainActor
 final class HotkeyControllerTests: XCTestCase {
-    /// Carbon key code for "F19" — a function key that almost certainly isn't bound,
+    /// Carbon key code for "F19" - a function key that almost certainly isn't bound,
     /// and is unlikely to fire while tests run.
     private let f19KeyCode: UInt32 = 80
 
@@ -38,7 +38,7 @@ final class HotkeyControllerTests: XCTestCase {
         XCTAssertEqual(controller.registeredIDsForTesting, ["toggle", "cycle"])
     }
 
-    /// Re-registering an existing id replaces the prior registration in place — and
+    /// Re-registering an existing id replaces the prior registration in place - and
     /// mints a FRESH Carbon hotkey id so a stale Carbon event in flight from the
     /// old binding cannot resolve to the new handler.
     func testRegisterReplacingSameIDMintsFreshCarbonID() {
@@ -59,7 +59,7 @@ final class HotkeyControllerTests: XCTestCase {
         )
     }
 
-    /// Re-registering also REPLACES the dispatched handler — so a stale handler
+    /// Re-registering also REPLACES the dispatched handler - so a stale handler
     /// from the previous registration cannot fire under the same id.
     func testRegisterReplacingSameIDReplacesDispatchedHandler() {
         let controller = HotkeyController()
@@ -87,7 +87,7 @@ final class HotkeyControllerTests: XCTestCase {
         XCTAssertFalse(controller.registeredIDsForTesting.contains("toggle"))
     }
 
-    /// Unregistering an unknown id is a no-op — does not throw, does not affect siblings.
+    /// Unregistering an unknown id is a no-op - does not throw, does not affect siblings.
     func testUnregisterUnknownIDIsNoOp() {
         let controller = HotkeyController()
         _ = controller.register("toggle", keyCode: f19KeyCode, modifiers: UInt32(cmdKey)) {}

--- a/Tests/NookKitTests/ModuleHostTests.swift
+++ b/Tests/NookKitTests/ModuleHostTests.swift
@@ -55,7 +55,7 @@ final class ModuleHostTests: XCTestCase {
         XCTAssertEqual(host.attentionModuleIDs, ["B"])
     }
 
-    /// `requestAttention(for:)` is a no-op for the foreground module — it is already on
+    /// `requestAttention(for:)` is a no-op for the foreground module - it is already on
     /// screen so there is nothing to badge.
     func testRequestAttentionIsNoOpForForegroundModule() {
         let a = StubModule(id: "A")
@@ -80,7 +80,7 @@ final class ModuleHostTests: XCTestCase {
         XCTAssertTrue(host.attentionModuleIDs.isEmpty)
     }
 
-    /// Switching to a module clears its attention badge — the user has now seen it.
+    /// Switching to a module clears its attention badge - the user has now seen it.
     func testSwitchClearsTargetModuleAttention() {
         let a = StubModule(id: "A")
         let b = StubModule(id: "B")
@@ -94,7 +94,7 @@ final class ModuleHostTests: XCTestCase {
         XCTAssertFalse(host.attentionModuleIDs.contains("B"), "switching to B clears B's badge")
     }
 
-    /// `attentionModuleIDs` is `@Published` — observers see each update.
+    /// `attentionModuleIDs` is `@Published` - observers see each update.
     func testAttentionModuleIDsIsPublished() {
         let a = StubModule(id: "A")
         let b = StubModule(id: "B")

--- a/Tests/NookKitTests/NookAppearancePreferencesTests.swift
+++ b/Tests/NookKitTests/NookAppearancePreferencesTests.swift
@@ -37,7 +37,7 @@ final class NookAppearancePreferencesTests: XCTestCase {
         XCTAssertEqual(decoded, original)
     }
 
-    /// The Liquid Glass surface style must survive a JSON round-trip like any other —
+    /// The Liquid Glass surface style must survive a JSON round-trip like any other - 
     /// its raw value is the seam a saved preference is restored through.
     func testLiquidGlassSurfaceStyleRoundTripsThroughJSON() throws {
         let original = NookAppearancePreferences(surfaceStyle: .liquidGlass)
@@ -47,7 +47,7 @@ final class NookAppearancePreferencesTests: XCTestCase {
     }
 
     /// JSON written by an older build can be missing later-added fields. Decoding it must
-    /// fill those fields with defaults instead of throwing — otherwise upgrading would
+    /// fill those fields with defaults instead of throwing - otherwise upgrading would
     /// silently reset every saved setting.
     func testDecodeIsForwardCompatibleWithMissingFields() throws {
         let partialJSON = #"{"chromePalette":"dark"}"#

--- a/Tests/NookKitTests/NookBackdropMappingTests.swift
+++ b/Tests/NookKitTests/NookBackdropMappingTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 /// Pins ``NookBackdropMapping`` to its rendering contract. The mapping is the only
 /// producer of ``NookBackdrop`` in the framework; if these change, downstream renders
-/// change too — so they're worth pinning explicitly.
+/// change too - so they're worth pinning explicitly.
 final class NookBackdropMappingTests: XCTestCase {
     private func preferences(
         palette: NookChromePalette,
@@ -39,7 +39,7 @@ final class NookBackdropMappingTests: XCTestCase {
         XCTAssertEqual(backdrop, .solid(.white))
     }
 
-    /// Reduce Transparency overrides the translucent style — the chrome must avoid
+    /// Reduce Transparency overrides the translucent style - the chrome must avoid
     /// `NSVisualEffectView` entirely.
     func testReduceTransparencyForcesSolidEvenWhenTranslucent() {
         let backdrop = NookBackdropMapping.notchBackdrop(
@@ -110,7 +110,7 @@ final class NookBackdropMappingTests: XCTestCase {
         XCTAssertEqual(backdrop, expected)
     }
 
-    /// The framework default — what every host gets before any mapping runs — must be
+    /// The framework default - what every host gets before any mapping runs - must be
     /// the solid-black fill so cold-launch rendering matches the historical chrome.
     func testDefaultBackdropIsSolidBlack() {
         XCTAssertEqual(NookBackdrop.solidBlack, .solid(.black))
@@ -150,7 +150,7 @@ final class NookBackdropMappingTests: XCTestCase {
         XCTAssertEqual(backdrop, expected)
     }
 
-    /// Reduce Transparency collapses Liquid Glass to a solid fill too — the glass
+    /// Reduce Transparency collapses Liquid Glass to a solid fill too - the glass
     /// material must not render when the user has opted out of translucency.
     func testReduceTransparencyForcesSolidEvenWhenLiquidGlass() {
         let backdrop = NookBackdropMapping.notchBackdrop(

--- a/Tests/NookKitTests/NookBrandingSeamTests.swift
+++ b/Tests/NookKitTests/NookBrandingSeamTests.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import XCTest
 @testable import NookKit
 
-/// Seam D — unified identity: single-module branding, the brand-mark override, and the
+/// Seam D - unified identity: single-module branding, the brand-mark override, and the
 /// menu-bar disable flag. Defaults reproduce today's chrome.
 @MainActor
 final class NookBrandingSeamTests: XCTestCase {
@@ -34,7 +34,7 @@ final class NookBrandingSeamTests: XCTestCase {
         XCTAssertFalse(moduleHost.showsMenuBarExtra)
     }
 
-    /// The menu-bar flag threads host → registry → ModuleHost.
+    /// The menu-bar flag threads host -> registry -> ModuleHost.
     func testMenuBarFlagThreadsFromHost() {
         var host = NookHostConfiguration()
         host.showsMenuBarExtra = false
@@ -45,7 +45,7 @@ final class NookBrandingSeamTests: XCTestCase {
         XCTAssertFalse(moduleHost.showsMenuBarExtra)
     }
 
-    /// Branding equality ignores the mark closure — two brandings are equal when their
+    /// Branding equality ignores the mark closure - two brandings are equal when their
     /// strings match, so existing `== .default` checks keep working with a mark set.
     func testBrandingEqualityIgnoresMark() {
         let plain = NookHostBranding(hostName: "X")

--- a/Tests/NookKitTests/NookChromeBehaviorTests.swift
+++ b/Tests/NookKitTests/NookChromeBehaviorTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import NookKit
 
 /// Host-global chrome behavior: hover side-effects, the cold-launch shimmer opt-out, and
-/// the appearance→backdrop mapping override — all defaulting to today's behavior and
+/// the appearance->backdrop mapping override - all defaulting to today's behavior and
 /// threaded from the host (or, single-module, forwarded from `NookConfiguration`).
 ///
 /// `@MainActor`: `AppCoordinator` / `ModuleHost` are main-actor isolated.
@@ -34,7 +34,7 @@ final class NookChromeBehaviorTests: XCTestCase {
     }
 
     /// Defaults reproduce the framework: no hover side-effects, the shimmer plays, and no
-    /// backdrop override — and both configuration structs default to that.
+    /// backdrop override - and both configuration structs default to that.
     func testDefaultsReproduceFramework() {
         let behavior = NookChromeBehavior.default
         XCTAssertEqual(behavior.hoverBehavior, [])
@@ -90,7 +90,7 @@ final class NookChromeBehaviorTests: XCTestCase {
         XCTAssertEqual(surface.backdrop, .solid(.red))
     }
 
-    /// Without an override, the framework mapping applies — a `.dark` + `.solid`
+    /// Without an override, the framework mapping applies - a `.dark` + `.solid`
     /// appearance maps to opaque black regardless of the system scheme.
     func testDefaultBackdropUsesFrameworkMapping() {
         let appState = AppState()

--- a/Tests/NookKitTests/NookChromeStyleTests.swift
+++ b/Tests/NookKitTests/NookChromeStyleTests.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import XCTest
 @testable import NookKit
 
-/// Seam C — chrome labels, layout metrics, in-panel motion, and the status/severity
+/// Seam C - chrome labels, layout metrics, in-panel motion, and the status/severity
 /// channel. Defaults reproduce today's chrome; the configuration carries host overrides.
 @MainActor
 final class NookChromeStyleTests: XCTestCase {

--- a/Tests/NookKitTests/NookConfigurationTests.swift
+++ b/Tests/NookKitTests/NookConfigurationTests.swift
@@ -20,7 +20,7 @@ final class NookConfigurationTests: XCTestCase {
     func testDefaultConfigurationIsComplete() {
         let configuration = NookConfiguration()
 
-        // Content closures are non-optional — invoking them must not trap.
+        // Content closures are non-optional - invoking them must not trap.
         _ = configuration.home()
         _ = configuration.compactLeading()
         _ = configuration.compactTrailing()
@@ -50,7 +50,7 @@ final class NookConfigurationTests: XCTestCase {
     }
 
     /// The coordinator projects the configuration's lifecycle hooks onto the surface
-    /// so transitions from any source — host, hover, drag — reach the host.
+    /// so transitions from any source - host, hover, drag - reach the host.
     @MainActor
     func testCoordinatorProjectsLifecycleHooksOntoTheSurface() {
         var configuration = NookConfiguration()
@@ -94,7 +94,7 @@ final class NookConfigurationTests: XCTestCase {
     }
 
     /// By default the trailing cluster carries no host items, so the top bar renders
-    /// exactly the framework chrome (just the keep-open lock and gear) — unchanged.
+    /// exactly the framework chrome (just the keep-open lock and gear) - unchanged.
     func testTopBarTrailingItemsDefaultsToNil() {
         let configuration = NookConfiguration()
 
@@ -123,7 +123,7 @@ final class NookConfigurationTests: XCTestCase {
         XCTAssertTrue(flag.didBuild)
     }
 
-    /// The default configuration ships the full framework chrome — top bar and Settings.
+    /// The default configuration ships the full framework chrome - top bar and Settings.
     func testDefaultConfigurationEnablesChrome() {
         let configuration = NookConfiguration()
 
@@ -142,7 +142,7 @@ final class NookConfigurationTests: XCTestCase {
     }
 
     /// With Settings disabled, `showSettings()` must not move the surface off the home
-    /// view — there is no Settings UI to show.
+    /// view - there is no Settings UI to show.
     @MainActor
     func testShowSettingsKeepsHomeWhenSettingsDisabled() {
         var configuration = NookConfiguration()

--- a/Tests/NookKitTests/NookContentInsetsTests.swift
+++ b/Tests/NookKitTests/NookContentInsetsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 /// chrome's own pre-padding stops clearing a curve.
 final class NookContentInsetsTests: XCTestCase {
 
-    // Matches `NookView`'s expanded-content safe-area strip — the historical
+    // Matches `NookView`'s expanded-content safe-area strip - the historical
     // fixed geometry (`NookStyle.standardExpandedContentInsets`): 0 top, 8 elsewhere.
     private let chromeSafeAreaInsets = NookStyle.standardExpandedContentInsets
 
@@ -34,7 +34,7 @@ final class NookContentInsetsTests: XCTestCase {
 
     /// Guards the wiring default, not just the derivation math: `NookStyle.standard`
     /// (and any `NookStyle` built without overriding `expandedContentInsets`) must
-    /// carry the historical strip — 0 on top, 8 on the other three edges. A future
+    /// carry the historical strip - 0 on top, 8 on the other three edges. A future
     /// edit to the default would silently reshape the shipped geometry without this.
     func testStandardStyleCarriesLegacyExpandedInsets() {
         let expected = NookEdgeInsets(top: 0, bottom: 8, leading: 8, trailing: 8)
@@ -91,7 +91,7 @@ final class NookContentInsetsTests: XCTestCase {
         XCTAssertEqual(perEdge.trailing, 12)
     }
 
-    /// Tightening only the bottom inset (8 → 2) leaves top/leading/trailing untouched
+    /// Tightening only the bottom inset (8 -> 2) leaves top/leading/trailing untouched
     /// and *raises* the bottom residual: with 6 pt less chrome pre-padding, content
     /// pinned into a bottom corner must inset 6 pt more to clear the same curve. The
     /// chrome's own bottom safe-area strip shrinks by 6 pt, so centered content sits
@@ -115,7 +115,7 @@ final class NookContentInsetsTests: XCTestCase {
 
     /// The chrome's horizontal pre-pad is `topCornerRadius + chromeSafeAreaInset`.
     /// A `bottomCornerRadius` equal to that threshold has zero horizontal
-    /// residual — the chrome already insets exactly enough horizontally to
+    /// residual - the chrome already insets exactly enough horizontally to
     /// clear the bottom-corner flare.
     func testNotchExpandedHorizontalResidualClampsAtZero() {
         let insets = NookContentInsets.expanded(

--- a/Tests/NookKitTests/NookDisplayPreferenceTests.swift
+++ b/Tests/NookKitTests/NookDisplayPreferenceTests.swift
@@ -35,14 +35,14 @@ final class NookDisplayPreferenceTests: XCTestCase {
     }
 
     /// An unrecognized `mode` (e.g. JSON from a newer build) must degrade to the default
-    /// rather than throw — a decode failure would wipe the user's other saved settings.
+    /// rather than throw - a decode failure would wipe the user's other saved settings.
     func testUnknownModeDecodesToDefault() throws {
         let data = Data(#"{"mode":"someFutureMode"}"#.utf8)
         let decoded = try JSONDecoder().decode(NookDisplayPreference.self, from: data)
         XCTAssertEqual(decoded, .default)
     }
 
-    /// A `.specific` record with no UUID is incoherent — it can't name a display — so it
+    /// A `.specific` record with no UUID is incoherent - it can't name a display - so it
     /// degrades to the default instead of resolving to an empty-string UUID.
     func testSpecificWithoutUUIDDecodesToDefault() throws {
         let data = Data(#"{"mode":"specific"}"#.utf8)
@@ -71,7 +71,7 @@ final class NookDisplayPreferenceTests: XCTestCase {
     /// requested UUID is not in the connected set (i.e. the user picked an external
     /// display and it has since been unplugged), the resolver must return the
     /// built-in panel if present, otherwise the main screen, otherwise the first
-    /// attached — in that order, NOT an arbitrary screen.
+    /// attached - in that order, NOT an arbitrary screen.
     func testSpecificUnpluggedResolvesViaBuiltInThenMainThenFirst() throws {
         guard !NSScreen.screens.isEmpty else {
             throw XCTSkip("No display attached in this environment.")

--- a/Tests/NookKitTests/NookFilePickerTests.swift
+++ b/Tests/NookKitTests/NookFilePickerTests.swift
@@ -15,7 +15,7 @@ import XCTest
 /// The `NSOpenPanel` / `NSSavePanel` presentation itself cannot run in a headless test
 /// (it shows real UI and needs an active app), so it is exercised manually against the
 /// signed app. The ``NookFilePresenting`` protocol is what lets *module* code that calls
-/// the picker be tested with a fake — demonstrated by ``testProtocolSeamAcceptsAFake``.
+/// the picker be tested with a fake - demonstrated by ``testProtocolSeamAcceptsAFake``.
 @MainActor
 final class NookFilePickerTests: XCTestCase {
     // MARK: - NookFileSelection
@@ -54,8 +54,8 @@ final class NookFilePickerTests: XCTestCase {
 
     // MARK: - Host wiring
 
-    /// A module's resolved picker is the registry's single shared instance — not the
-    /// inert default — so it can actually present and hold the surface.
+    /// A module's resolved picker is the registry's single shared instance - not the
+    /// inert default - so it can actually present and hold the surface.
     func testModuleContextResolvesTheRegistrySharedPicker() {
         let registry = makeRegistry(ids: ["A"])
         let resolved = registry.context(for: "A")?.services.resolve(NookFilePickerKey.self)
@@ -65,7 +65,7 @@ final class NookFilePickerTests: XCTestCase {
         XCTAssertTrue(resolvedPicker === registry.filePicker, "every module shares the one process-wide picker")
     }
 
-    /// Two modules in the same host resolve the same picker instance — the guarantee
+    /// Two modules in the same host resolve the same picker instance - the guarantee
     /// that lets it serialize presentation process-wide.
     func testAllModulesShareOnePicker() {
         let registry = makeRegistry(ids: ["A", "B"])
@@ -77,7 +77,7 @@ final class NookFilePickerTests: XCTestCase {
     }
 
     /// An `AppServices` that never went through the host registry falls back to the
-    /// inert default — total resolution, never `nil`, and not a live picker.
+    /// inert default - total resolution, never `nil`, and not a live picker.
     func testUnregisteredServicesResolveToInertDefault() {
         let resolved = AppServices().resolve(NookFilePickerKey.self)
         XCTAssertNil(resolved as? NookFilePicker, "the default is the inert stand-in, not a real picker")

--- a/Tests/NookKitTests/NookHapticsTests.swift
+++ b/Tests/NookKitTests/NookHapticsTests.swift
@@ -10,10 +10,10 @@ import XCTest
 
 /// Coverage for ``NookHaptics``. The actual trackpad pulse is hardware-dependent
 /// (Force Touch trackpad + the user's System Settings) so we can only verify the
-/// preference-gating contract — the call site is documented as the authoritative
+/// preference-gating contract - the call site is documented as the authoritative
 /// place where the preference is read.
 final class NookHapticsTests: XCTestCase {
-    /// `confirm(enabled: false)` is a safe no-op — explicitly so when the preference
+    /// `confirm(enabled: false)` is a safe no-op - explicitly so when the preference
     /// is off. We can't observe the absence of a pulse directly, but the call must
     /// at least not crash.
     func testConfirmIsNoOpWhenDisabled() {

--- a/Tests/NookKitTests/NookHotkeyTests.swift
+++ b/Tests/NookKitTests/NookHotkeyTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class NookHotkeyTests: XCTestCase {
     func testDefaultHotkeyDisplaysCanonicalGlyphs() {
         // The default is Command-Option-Semicolon. macOS renders modifiers in canonical
-        // order (⌃⌥⇧⌘) — Command is always last, so this shows as "⌥⌘;".
+        // order (⌃⌥⇧⌘) - Command is always last, so this shows as "⌥⌘;".
         XCTAssertEqual(NookHotkey.default.displaySymbols, ["⌥", "⌘", ";"])
         XCTAssertEqual(NookHotkey.default.display, "⌥⌘;")
     }

--- a/Tests/NookKitTests/NookModuleRegistryTests.swift
+++ b/Tests/NookKitTests/NookModuleRegistryTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import NookKit
 
-/// Direct coverage for ``NookModuleRegistry`` — lazy construction, instance caching,
+/// Direct coverage for ``NookModuleRegistry`` - lazy construction, instance caching,
 /// `isLoaded` / `unload` lifecycle, descriptor lookup. The registry is the only piece
 /// that *retains* live module instances; getting this wrong leaks state across
 /// switches.
@@ -56,7 +56,7 @@ final class NookModuleRegistryTests: XCTestCase {
         XCTAssertFalse(registry.isLoaded("B"))
     }
 
-    /// A first `module(for:)` constructs and caches the module — `isLoaded` flips
+    /// A first `module(for:)` constructs and caches the module - `isLoaded` flips
     /// `true`, the factory ran exactly once.
     func testModuleForBuildsAndCachesOnFirstAccess() {
         let (registry, probe) = makeRegistry(ids: ["A"])
@@ -66,7 +66,7 @@ final class NookModuleRegistryTests: XCTestCase {
         XCTAssertEqual(probe.counts["A"], 1)
     }
 
-    /// A second `module(for:)` returns the same cached instance — the factory does
+    /// A second `module(for:)` returns the same cached instance - the factory does
     /// not re-run.
     func testModuleForReturnsSameInstanceOnSubsequentCalls() {
         let (registry, probe) = makeRegistry(ids: ["A"])
@@ -85,7 +85,7 @@ final class NookModuleRegistryTests: XCTestCase {
 
     // MARK: - Unload lifecycle
 
-    /// `unload(_:)` drops the cached instance — the next `module(for:)` rebuilds it.
+    /// `unload(_:)` drops the cached instance - the next `module(for:)` rebuilds it.
     func testUnloadDropsCachedInstanceAndForcesRebuild() {
         let (registry, probe) = makeRegistry(ids: ["A"])
         _ = registry.module(for: "A")

--- a/Tests/NookKitTests/NookPreferenceDefaultsTests.swift
+++ b/Tests/NookKitTests/NookPreferenceDefaultsTests.swift
@@ -60,7 +60,7 @@ final class NookPreferenceDefaultsTests: XCTestCase {
     }
 
     /// The default bag reproduces the framework exactly, and both configuration structs
-    /// default to it — so an unconfigured host behaves as before.
+    /// default to it - so an unconfigured host behaves as before.
     func testDefaultsReproduceFramework() {
         XCTAssertEqual(NookPreferenceDefaults.default, NookPreferenceDefaults())
         XCTAssertEqual(NookPreferenceDefaults.default.appearance, .default)
@@ -100,7 +100,7 @@ final class NookPreferenceDefaultsTests: XCTestCase {
         XCTAssertNotEqual(appState.appearancePreferences, customDefaults.appearance)
     }
 
-    /// Seeding must not write the host defaults to `UserDefaults` — otherwise a later
+    /// Seeding must not write the host defaults to `UserDefaults` - otherwise a later
     /// build couldn't revise them for users who never touched Settings.
     func testSeedIsNotPersisted() {
         _ = AppState(preferenceDefaults: customDefaults)
@@ -113,8 +113,8 @@ final class NookPreferenceDefaultsTests: XCTestCase {
         }
     }
 
-    /// The seeded appearance reaches the surface on the first backdrop sync — the path
-    /// the chrome's first paint uses — so a host's launch presentation is honored before
+    /// The seeded appearance reaches the surface on the first backdrop sync - the path
+    /// the chrome's first paint uses - so a host's launch presentation is honored before
     /// any user interaction.
     func testSeededPresentationReachesSurface() {
         let seeded = AppState(

--- a/Tests/NookKitTests/NookPresentationPinningTests.swift
+++ b/Tests/NookKitTests/NookPresentationPinningTests.swift
@@ -119,7 +119,7 @@ final class NookPresentationPinningTests: XCTestCase {
 
     func testServiceKeyDefaultValueIsAStableInstance() {
         // A test or a context that never went through the registry resolves the
-        // key to the static default — verify that resolve returns a usable
+        // key to the static default - verify that resolve returns a usable
         // (non-trapping) broker.
         let services = AppServices()
         let resolved = services.resolve(NookPresentationPinningKey.self)

--- a/Tests/NookKitTests/NookShapeTests.swift
+++ b/Tests/NookKitTests/NookShapeTests.swift
@@ -19,7 +19,7 @@ final class NookShapeTests: XCTestCase {
     // MARK: - animatableData round-trip
 
     /// `animatableData` is the seam SwiftUI animates radii through. Getting and setting
-    /// it must round-trip both values without re-ordering — the chrome's compact-to-
+    /// it must round-trip both values without re-ordering - the chrome's compact-to-
     /// expanded radius spring depends on it.
     func testAnimatableDataRoundTrip() {
         var shape = NookShape(form: .floating, topCornerRadius: 8, bottomCornerRadius: 24)
@@ -38,7 +38,7 @@ final class NookShapeTests: XCTestCase {
     /// the clamp, a small compact pill (width < 2×topCornerRadius) draws a
     /// self-intersecting path that renders as a glitchy crescent.
     func testFloatingPathClampsRadiiOnSmallRects() {
-        // Top radius 40, bottom radius 40, but the rect is only 30×30 — both must clamp
+        // Top radius 40, bottom radius 40, but the rect is only 30×30 - both must clamp
         // to 15 (the half-min).
         let tiny = CGRect(x: 0, y: 0, width: 30, height: 30)
         let path = NookShape(form: .floating, topCornerRadius: 40, bottomCornerRadius: 40)
@@ -74,7 +74,7 @@ final class NookShapeTests: XCTestCase {
             .path(in: rect)
         let bounds = path.boundingRect
 
-        // The path's bounding box must equal the host rect — a missing corner curve
+        // The path's bounding box must equal the host rect - a missing corner curve
         // would produce a smaller box.
         XCTAssertEqual(bounds.minX, rect.minX, accuracy: 0.5)
         XCTAssertEqual(bounds.maxX, rect.maxX, accuracy: 0.5)
@@ -84,7 +84,7 @@ final class NookShapeTests: XCTestCase {
 
     // MARK: - Notch path
 
-    /// The notch path's bounding box is the host rect — the eared top edge curves
+    /// The notch path's bounding box is the host rect - the eared top edge curves
     /// inward, not outward.
     func testNotchPathBoundingBoxMatchesHostRect() {
         let rect = CGRect(x: 0, y: 0, width: 520, height: 220)

--- a/Tests/NookKitTests/NookSurfaceConcurrencyTests.swift
+++ b/Tests/NookKitTests/NookSurfaceConcurrencyTests.swift
@@ -16,7 +16,7 @@ import XCTest
 ///
 /// These exercise `Nook`'s internal model without depending on a real display: the
 /// drag-session and generation logic is pure state, and `nookPanelDraggingEntered`
-/// only spawns a transition when a screen resolves — with no screen attached the
+/// only spawns a transition when a screen resolves - with no screen attached the
 /// session bookkeeping still runs and is what we assert on.
 @MainActor
 final class NookSurfaceConcurrencyTests: XCTestCase {
@@ -57,7 +57,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
     }
 
     /// Every `draggingUpdated` forwards as another enter. Repeated enters must keep the
-    /// *original* snapshot — they are idempotent no-ops on session state.
+    /// *original* snapshot - they are idempotent no-ops on session state.
     func testRepeatedDragEntersPreserveOriginalSnapshot() {
         let nook = makeNook()
         let url = URL(fileURLWithPath: "/tmp/a")
@@ -71,7 +71,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         XCTAssertEqual(nook.dragSession, .active(stateBeforeEntry: .hidden))
     }
 
-    /// AppKit can deliver `draggingExited` *then* `draggingEnded` for one session — both
+    /// AppKit can deliver `draggingExited` *then* `draggingEnded` for one session - both
     /// route through `nookPanelDraggingExited`. The second call must be an idempotent
     /// no-op: the snapshot was consumed by the first, so the session stays idle and the
     /// prior state is not restored twice.
@@ -84,7 +84,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         XCTAssertEqual(nook.dragSession, .idle)
         XCTAssertFalse(nook.isDragInFlight)
 
-        // Out-of-order / duplicate end callback — must not corrupt state.
+        // Out-of-order / duplicate end callback - must not corrupt state.
         nook.nookPanelDraggingExited()
         XCTAssertEqual(nook.dragSession, .idle)
         XCTAssertFalse(nook.isDragInFlight)
@@ -113,7 +113,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         XCTAssertEqual(nook.dragSession, .idle)
         XCTAssertFalse(nook.isDragInFlight)
 
-        // AppKit's post-drop exit/end — idempotent no-op.
+        // AppKit's post-drop exit/end - idempotent no-op.
         nook.nookPanelDraggingExited()
         XCTAssertEqual(nook.dragSession, .idle)
     }
@@ -128,7 +128,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         XCTAssertFalse(nook.isDragInFlight)
     }
 
-    /// `isDragInFlight` is a strict mirror of `dragSession` — observers of the published
+    /// `isDragInFlight` is a strict mirror of `dragSession` - observers of the published
     /// bool see exactly the active/idle of the authoritative enum.
     func testIsDragInFlightMirrorsSession() {
         let nook = makeNook()
@@ -145,7 +145,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
 
     /// `runTransition` claims a fresh generation synchronously and invalidates the prior
     /// one. A generation a transition's body captured is no longer `isCurrent` once a
-    /// newer transition has been claimed — this is the signal an in-flight `_hide`
+    /// newer transition has been claimed - this is the signal an in-flight `_hide`
     /// re-checks to bail out of its teardown rather than deinit a window the newer
     /// transition owns.
     func testNewerTransitionSupersedesAnEarlierGeneration() async {
@@ -169,14 +169,14 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         await hideTask.value
         await expandTask.value
 
-        // The hide observed itself superseded after the yield — its teardown bails.
+        // The hide observed itself superseded after the yield - its teardown bails.
         XCTAssertEqual(hideStillCurrentAfterSupersede, false)
         // The expand is the most recent claim and owns the surface.
         XCTAssertEqual(expandGenerationIsCurrent, true)
     }
 
-    /// `supersedeInFlightTransition` — used by the synchronous window-swap paths
-    /// (`presentation.didSet`, screen-parameter observer) — invalidates any in-flight
+    /// `supersedeInFlightTransition` - used by the synchronous window-swap paths
+    /// (`presentation.didSet`, screen-parameter observer) - invalidates any in-flight
     /// generation so a mid-flight `_expand`/`_compact`/`_hide` bails when the window is
     /// rebuilt under it.
     func testWindowSwapSupersedesInFlightTransition() async {
@@ -194,7 +194,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         XCTAssertEqual(stillCurrentAfterSwap, false)
     }
 
-    /// An awaited `hide()` always resolves — it now routes through `runTransition` like
+    /// An awaited `hide()` always resolves - it now routes through `runTransition` like
     /// `expand`/`compact`, so the awaited task completes rather than wedging on a dropped
     /// continuation. With no window to tear down it is effectively a fast no-op.
     func testAwaitedHideOnHiddenNookResolves() async {
@@ -291,7 +291,7 @@ final class NookSurfaceConcurrencyTests: XCTestCase {
         XCTAssertFalse(nook.isLayoutGraceActive)
     }
 
-    /// Hover-exit auto-compact must not run while layout grace is active — the common
+    /// Hover-exit auto-compact must not run while layout grace is active - the common
     /// failure when expanded content shrinks under a stationary cursor.
     func testLayoutGraceSuppressesHoverExitCompact() async throws {
         guard let screen = NSScreen.main else {

--- a/Tests/NookKitTests/SurfaceArbiterTests.swift
+++ b/Tests/NookKitTests/SurfaceArbiterTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @MainActor
 final class SurfaceArbiterTests: XCTestCase {
     /// Drives a `SurfaceArbiter` with fully controllable engagement, active module, and
-    /// surface state — no real window. `runSerial` runs operations inline.
+    /// surface state - no real window. `runSerial` runs operations inline.
     @MainActor
     private final class Harness {
         var engaged = false
@@ -129,7 +129,7 @@ final class SurfaceArbiterTests: XCTestCase {
         harness.arbiter.invalidateClaims(ownedBy: "A")
         let transitionsBeforeEnd = harness.transitions.count
 
-        // A stale `end` must not touch the surface — no restore, no transition.
+        // A stale `end` must not touch the surface - no restore, no transition.
         await harness.arbiter.end(token!)
         XCTAssertEqual(harness.transitions.count, transitionsBeforeEnd, "stale end is a no-op")
         XCTAssertEqual(harness.state, .expanded)
@@ -175,7 +175,7 @@ final class SurfaceArbiterTests: XCTestCase {
 
     // MARK: - Watchdog
 
-    /// The watchdog default is 30 s — a wall-clock safety net, not flow control.
+    /// The watchdog default is 30 s - a wall-clock safety net, not flow control.
     /// Pinned so a future "tune the default" change has to update this test and think
     /// about whether well-behaved presenters still clear it.
     func testDefaultMaxDurationIsThirtySeconds() {
@@ -238,7 +238,7 @@ final class SurfaceArbiterTests: XCTestCase {
         )
     }
 
-    /// Invalidating a module's claims cancels their watchdogs too — otherwise a
+    /// Invalidating a module's claims cancels their watchdogs too - otherwise a
     /// just-switched-away module's stuck watchdog would synthesize an `end` against
     /// a stale token (harmless) but still racing through `runSerial` for nothing.
     func testWatchdogCancelledOnInvalidate() async throws {
@@ -262,7 +262,7 @@ final class SurfaceArbiterTests: XCTestCase {
         )
     }
 
-    /// `maxDuration: nil` opts the claim out of the watchdog — for an intentional
+    /// `maxDuration: nil` opts the claim out of the watchdog - for an intentional
     /// long-running takeover the host has explicitly chosen.
     func testNilMaxDurationDisablesWatchdog() async throws {
         let harness = Harness()

--- a/project.yml
+++ b/project.yml
@@ -48,7 +48,7 @@ targets:
       - path: App
         excludes:
           - "Info.plist"
-          # Reference template only — committed so module authors can copy it. NOT wired
+          # Reference template only - committed so module authors can copy it. NOT wired
           # via CODE_SIGN_ENTITLEMENTS, so the demo stays unsandboxed and the dev loop is
           # unaffected. Excluded here so it isn't bundled as a stray resource. To actually
           # sandbox the app, add `CODE_SIGN_ENTITLEMENTS: App/Nook.entitlements` below.

--- a/site/src/content/docs/404.mdx
+++ b/site/src/content/docs/404.mdx
@@ -1,10 +1,10 @@
 ---
 title: Page not found
-description: The page you’re looking for doesn’t exist or may have moved.
+description: The page you're looking for doesn't exist or may have moved.
 template: splash
 hero:
   title: Page not found
-  tagline: The page you’re looking for doesn’t exist or may have moved.
+  tagline: The page you're looking for doesn't exist or may have moved.
   actions:
     - text: Home
       link: /

--- a/site/src/content/docs/guides/layout-and-insets.mdx
+++ b/site/src/content/docs/guides/layout-and-insets.mdx
@@ -4,9 +4,9 @@ description: How expanded width, chrome insets, and nookContentInsets compose in
 ---
 
 The expanded panel's **glass width** and the **content column** inside it are controlled
-by different knobs on different layers. Stacking horizontal padding — for example
+by different knobs on different layers. Stacking horizontal padding - for example
 `.padding(.horizontal, 12)` on a home view when the framework already applies
-`metrics.edgePadding` — is the most common cause of dead space beside answer text
+`metrics.edgePadding` - is the most common cause of dead space beside answer text
 and bottom command rows.
 
 This guide maps each knob, shows how they compose, and points at
@@ -16,14 +16,14 @@ This guide maps each knob, shows how they compose, and points at
 
 Expanded layout stacks three responsibilities:
 
-1. **`NookSurface` (`NookView`)** — clips the notch shape, applies
+1. **`NookSurface` (`NookView`)** - clips the notch shape, applies
    `NookStyle.expandedContentInsets` as `.safeAreaInset` strips, adds structural
    horizontal padding (`topCornerRadius`) for the panel ears, and derives the outer
    `nookContentInsets` from corner radii.
-2. **`NookKit` (`NookExpandedView`)** — pins the inner VStack to
+2. **`NookKit` (`NookExpandedView`)** - pins the inner VStack to
    `expandedWidth`, wraps it in `metrics.edgePadding`, and re-injects reduced
    `nookContentInsets` for descendants.
-3. **Host views** — read `@Environment(\.nookContentInsets)` when content pins to an
+3. **Host views** - read `@Environment(\.nookContentInsets)` when content pins to an
    edge or corner; use `frame(maxWidth: .infinity, …)` when a row should span the
    full content column.
 
@@ -47,21 +47,21 @@ Expanded layout stacks three responsibilities:
 
 | Knob | Layer | What it does |
 |------|-------|--------------|
-| `NookConfiguration.expandedWidth` | NookKit | Fixed width of the inner VStack (default 520). Does not resize the glass by itself — the surface measures the wrapped chrome. |
+| `NookConfiguration.expandedWidth` | NookKit | Fixed width of the inner VStack (default 520). Does not resize the glass by itself - the surface measures the wrapped chrome. |
 | `NookChromeMetrics.edgePadding` | NookKit | Padding around the inner VStack inside the expanded surface. Default `8` (`NookLayout.edgePadding`). Subtracted before re-injecting `nookContentInsets`. |
 | `NookStyle.expandedContentInsets` | NookSurface | Per-edge `.safeAreaInset` strip the chrome reserves around expanded content. Default: top `0`, other edges `8`. |
 | `NookStyle.topCornerRadius` / `bottomCornerRadius` | NookSurface | Panel corner radii; drive clip shape and `nookContentInsets` derivation. |
-| `EnvironmentValues.nookContentInsets` | Surface → host | Residual curve clearance **relative to the host content frame**. Use for edge/corner-pinned layout — not as a substitute for centering. |
+| `EnvironmentValues.nookContentInsets` | Surface -> host | Residual curve clearance **relative to the host content frame**. Use for edge/corner-pinned layout - not as a substitute for centering. |
 
 `expandedContentInsets` and `edgePadding` both default to **8 pt** on the sides for
 historical parity, but they are **independent knobs** on different layers.
 
 ## Usable content width (worked example)
 
-At the framework defaults — `expandedWidth = 520`, radii top `19` / bottom `24`,
+At the framework defaults - `expandedWidth = 520`, radii top `19` / bottom `24`,
 `expandedContentInsets` `(0, 8, 8, 8)`, `edgePadding = 8`:
 
-**Step 1 — outer `nookContentInsets`** (injected by `NookView`):
+**Step 1 - outer `nookContentInsets`** (injected by `NookView`):
 
 | Edge | Residual |
 |------|----------|
@@ -70,7 +70,7 @@ At the framework defaults — `expandedWidth = 520`, radii top `19` / bottom `24
 | leading | 16 |
 | trailing | 16 |
 
-**Step 2 — inner `nookContentInsets`** (after `NookExpandedView` subtracts
+**Step 2 - inner `nookContentInsets`** (after `NookExpandedView` subtracts
 `edgePadding`):
 
 | Edge | Residual |
@@ -80,13 +80,13 @@ At the framework defaults — `expandedWidth = 520`, radii top `19` / bottom `24
 | leading | 8 |
 | trailing | 8 |
 
-**Step 3 — edge-aligned text width** inside the 520 pt VStack:
+**Step 3 - edge-aligned text width** inside the 520 pt VStack:
 
 ```
 520 − leading(8) − trailing(8) = 504 pt
 ```
 
-`SettingsView` and `NookTopBar` follow this pattern — section labels and icon
+`SettingsView` and `NookTopBar` follow this pattern - section labels and icon
 clusters pad by `contentInsets.leading` / `contentInsets.trailing` so everything
 shares one left margin.
 
@@ -97,7 +97,7 @@ shares one left margin.
 
 - Inner VStack width: **600 pt**
 - Edge-aligned usable width: **600 − 8 − 8 = 584 pt**
-- `nookContentInsets.bottom` **rises** to 22 (24 − 2) — bottom-*corner* content must
+- `nookContentInsets.bottom` **rises** to 22 (24 − 2) - bottom-*corner* content must
   inset more; horizontally-centered rows are unaffected and sit ~6 pt closer to the
   rounded bottom.
 
@@ -118,7 +118,7 @@ NookApp.main(configuration)
 ```
 
 Leave `metrics.edgePadding` at the default unless you have a deliberate reason to
-change the wrapper padding — most hosts only need `expandedWidth` and
+change the wrapper padding - most hosts only need `expandedWidth` and
 `expandedContentInsets`.
 
 ### Read `nookContentInsets` in the home view
@@ -148,26 +148,26 @@ struct MyHomeView: View {
 ```
 
 Do **not** add `.padding(.horizontal, 12)` (or any fixed horizontal padding) on the
-home root — `NookExpandedView` already applies `metrics.edgePadding`. Extra padding
+home root - `NookExpandedView` already applies `metrics.edgePadding`. Extra padding
 narrows the effective column and leaves visible dead space beside text and toolbars.
 
 ### Full-width bottom command rows
 
 Bottom toolbars that should span the content column need two things:
 
-1. **`frame(maxWidth: .infinity, alignment: .leading)`** on the row — otherwise
+1. **`frame(maxWidth: .infinity, alignment: .leading)`** on the row - otherwise
    SwiftUI shrink-wraps the `HStack` to its buttons and the row looks narrower than
    the panel.
-2. **Edge insets from `nookContentInsets`** — not a second horizontal padding pass.
+2. **Edge insets from `nookContentInsets`** - not a second horizontal padding pass.
 
 Centered command rows (icons in the middle of the panel) can ignore horizontal
 `nookContentInsets`; only corner-pinned content needs the leading/trailing values.
 
 ### When you can skip `nookContentInsets`
 
-- **Centered placeholder content** (title + subtitle in the middle) — the default
+- **Centered placeholder content** (title + subtitle in the middle) - the default
   demo home does this with vertical padding only.
-- **Full-bleed custom art** that intentionally reaches toward the curves — rare; test
+- **Full-bleed custom art** that intentionally reaches toward the curves - rare; test
   on a notched display.
 
 When content aligns with Settings rows or the top-bar leading cluster, always use
@@ -187,13 +187,13 @@ the registered home view before tuning `expandedWidth`.
 
 ## See also
 
-- `Examples/LayoutNook/main.swift` — working 600 pt host with trimmed bottom inset
+- `Examples/LayoutNook/main.swift` - working 600 pt host with trimmed bottom inset
   and a full-width command row.
-- [Theming](/guides/theming/#chrome-shape-animation-and-width) — corner radii and
+- [Theming](/guides/theming/#chrome-shape-animation-and-width) - corner radii and
   `expandedContentInsets` in context.
-- [Settings chrome](/guides/settings-chrome/) — top-bar layout that shares the same
+- [Settings chrome](/guides/settings-chrome/) - top-bar layout that shares the same
   inset contract.
-- `Sources/NookKit/App/Views/Settings/SettingsView.swift` — canonical edge-aligned
+- `Sources/NookKit/App/Views/Settings/SettingsView.swift` - canonical edge-aligned
   list layout inside the framework.
-- `Tests/NookKitTests/NookContentInsetsTests.swift` — executable spec for inset
+- `Tests/NookKitTests/NookContentInsetsTests.swift` - executable spec for inset
   derivation math.

--- a/site/src/content/docs/start/first-nook.mdx
+++ b/site/src/content/docs/start/first-nook.mdx
@@ -65,6 +65,6 @@ threaded into views.
 `hideNook()`, `toggleNook()`, `toggleKeepNookOpen()`. The global hotkey and
 menu-bar fallback already call into them.
 
-Rename the product (`Nook` → your app) by editing `project.yml`,
+Rename the product (`Nook` -> your app) by editing `project.yml`,
 `App/Info.plist`, and the `Package.swift` product name when you're ready
 to ship. See [Shipping](/guides/shipping/) for the full checklist.

--- a/site/src/content/docs/start/install.mdx
+++ b/site/src/content/docs/start/install.mdx
@@ -38,6 +38,6 @@ and `NookSurface`. `NookComponents` is opt-in.
 
 ## In Xcode
 
-File → Add Package Dependencies, paste
+File -> Add Package Dependencies, paste
 `https://github.com/glendonC/opennook`, and add the `NookApp` product
 (and `NookComponents` if you want it) to your app target.


### PR DESCRIPTION
## Summary
- Convert em/en dashes, curly quotes, ellipsis, and arrow glyphs to ASCII in Swift comments, shell/YAML comments, and markdown/MDX prose across Sources, Tests, Examples, and the docs site (~118 files, ~700 line edits).
- Preserve all string literals, code fences, inline code, Mac key glyphs, accents (e.g. `Préférences`), middot, emoji, and box-drawing art unchanged.
- Add `Scripts/normalize-ascii-typography.py`, `Scripts/check-ascii.sh`, and a CI job that fails if banned typography reappears in comment/markdown prose.

## Test plan
- [x] `./Scripts/check-ascii.sh`
- [x] `swift build && swift test --parallel`
- [x] `OPENNOOK_BUILD_DOCS=1 ./Scripts/generate-docs.sh`
- [x] `cd site && npm run build`
- [x] Post-scan confirms remaining non-ASCII is intentional (string data, key glyphs, accents, diagram art)