### PR TITLE
Add repo hygiene and contributor guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Dual-license boundary: NookSurface stays MIT and must stay thin.
+/Sources/NookSurface/ @glendonC
+/Tests/NookKitTests/NookSurfaceConcurrencyTests.swift @glendonC
+/Tests/NookKitTests/NookShapeTests.swift @glendonC

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /site
+    schedule:
+      interval: weekly
+    groups:
+      site:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ xcuserdata/
 # after editing project.yml.
 Nook.xcodeproj/
 .swiftpm/
+# Library package - resolved pins are local/CI-specific, not committed.
+Package.resolved
 
 # Generated DocC output (Scripts/generate-docs.sh). The hosted API reference is
 # built by Swift Package Index from .spi.yml, so this never needs committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,15 +98,18 @@ the failure mode this section exists to prevent.
 
 ## Submitting a change
 
-1. Branch off `main` (don't commit on `main` directly).
+1. Branch off `main` (don't commit on `main` directly). `main` is protected -
+   changes land through a PR with green CI.
 2. Make the change. Run `swift build && swift test` locally.
 3. If you added or changed public API, add a `CHANGELOG.md` entry and update
    the docs site (see [Documentation](#documentation)).
-4. If you touched `Sources/NookSurface/` or added/removed Swift files,
+4. If you touched comments or docs prose, run `./Scripts/check-ascii.sh`.
+5. If you touched `Sources/NookSurface/` or added/removed Swift files,
    verify the license-header job locally:
    `grep -L 'SPDX-License-Identifier' $(find Sources Tests Examples App -name '*.swift')`
    should print nothing.
-5. Open a PR using the template. CI must be green before review.
+6. Open a PR using the template. CI must be green before merge. Merge with
+   rebase to keep history linear.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `CODEOWNERS` for the NookSurface MIT boundary.
- Add Dependabot for `site/` npm deps and GitHub Actions.
- Document `./Scripts/check-ascii.sh`, protected `main`, and rebase merge in CONTRIBUTING.
- Ignore `Package.resolved` (library package; pins stay local).

## Test plan
- [x] Docs-only change; no build impact
- Branch protection and rebase-only merge settings applied on GitHub separately