### PR TITLE
Require docs site build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,3 +156,19 @@ jobs:
       # time instead of silently breaking the next release's hosted docs.
       - name: Build the API reference
         run: ./Scripts/generate-docs.sh
+
+  site:
+    name: Docs site build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: site/.node-version
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install and build the Starlight site
+        working-directory: site
+        run: |
+          npm ci
+          npm run build


### PR DESCRIPTION
## Summary
- Add a `Docs site build` job (`npm ci && npm run build` in `site/`) on `ubuntu-latest`.
- Closes the gap where Swift/DocC CI could pass while Starlight MDX breaks.

## Test plan
- [x] `cd site && npm ci && npm run build` locally
- [ ] Branch protection updated to require the new check after merge