### PR TITLE
Add release automation for semver tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+# Cut a GitHub Release when a semver tag is pushed.
+#
+# Human workflow:
+#   1. Move [Unreleased] notes into ## [X.Y.Z] - YYYY-MM-DD in CHANGELOG.md
+#   2. Merge to main
+#   3. git tag vX.Y.Z && git push origin vX.Y.Z
+#
+# This workflow validates the CHANGELOG section, builds DocC, and attaches the
+# static archive. Swift Package Index picks up the tag via .spi.yml separately.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish release
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Validate CHANGELOG entry
+        run: ./Scripts/validate-release-changelog.sh "${{ github.ref_name }}"
+
+      - name: Build DocC archive
+        run: ./Scripts/generate-docs.sh
+
+      - name: Package DocC output
+        run: |
+          set -euo pipefail
+          archive="opennook-docs-${{ github.ref_name }}.zip"
+          (cd .docs-out && zip -r "../${archive}" .)
+          echo "ARCHIVE=${archive}" >> "$GITHUB_ENV"
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          {
+            echo "body<<EOF"
+            ./Scripts/extract-changelog-section.sh "$version"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: OpenNook ${{ github.ref_name }}
+          body: ${{ steps.notes.outputs.body }}
+          files: ${{ env.ARCHIVE }}
+          generate_release_notes: false

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -25,3 +25,22 @@ the iteration:
 
 `swift test` runs the test suite from the package root. Both paths share the
 same module artifacts via SwiftPM, so behavior cannot drift.
+
+## Cutting a release
+
+1. Move `[Unreleased]` notes into `## [X.Y.Z] - YYYY-MM-DD` in `CHANGELOG.md`
+   and update the compare links at the bottom.
+2. Merge to `main`.
+3. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+Pushing a semver tag triggers `.github/workflows/release.yml`, which checks the
+CHANGELOG section, builds DocC, and publishes a GitHub Release with the notes
+and a `opennook-docs-vX.Y.Z.zip` attachment. Swift Package Index builds API
+docs from the same tag via `.spi.yml`.
+
+Validate locally before tagging:
+
+```sh
+./Scripts/validate-release-changelog.sh vX.Y.Z
+./Scripts/extract-changelog-section.sh X.Y.Z   # preview release notes
+```

--- a/Scripts/extract-changelog-section.sh
+++ b/Scripts/extract-changelog-section.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Print the Keep a Changelog body for a released version (header excluded).
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <version-without-v>" >&2
+  exit 2
+fi
+
+version="$1"
+changelog="${CHANGELOG:-CHANGELOG.md}"
+
+if [[ ! -f "$changelog" ]]; then
+  echo "missing $changelog" >&2
+  exit 1
+fi
+
+awk -v version="$version" '
+  $0 ~ "^## \\[" version "\\]" { capture = 1; next }
+  capture && $0 ~ "^## \\[" { exit }
+  capture { print }
+' "$changelog"

--- a/Scripts/validate-release-changelog.sh
+++ b/Scripts/validate-release-changelog.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Fail if a git tag does not have a non-empty CHANGELOG section.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <tag-or-version>" >&2
+  exit 2
+fi
+
+raw="$1"
+tag="${raw#v}"
+changelog="${CHANGELOG:-CHANGELOG.md}"
+
+if [[ ! "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "tag must look like vMAJOR.MINOR.PATCH (got: $raw)" >&2
+  exit 1
+fi
+
+if [[ ! -f "$changelog" ]]; then
+  echo "missing $changelog" >&2
+  exit 1
+fi
+
+if ! grep -q "^## \\[$tag\\]" "$changelog"; then
+  echo "CHANGELOG.md has no section for [$tag]" >&2
+  exit 1
+fi
+
+body="$(CHANGELOG="$changelog" "$(dirname "$0")/extract-changelog-section.sh" "$tag" | sed '/^[[:space:]]*$/d')"
+if [[ -z "$body" ]]; then
+  echo "CHANGELOG section [$tag] is empty" >&2
+  exit 1
+fi
+
+echo "CHANGELOG section [$tag] OK"

--- a/Tests/NookKitTests/AppCoordinatorTests.swift
+++ b/Tests/NookKitTests/AppCoordinatorTests.swift
@@ -518,36 +518,38 @@ final class AppCoordinatorTests: XCTestCase {
     /// onto one *intent change* (suspended -> bound), and `removeDuplicates` then dedups
     /// transitional duplicates.
     func testHotkeyRebindFiresExactlyOneRegisterPerUserAction() async throws {
-        let log = ExpandLog()
-        let a = SpyModule(id: "A", expandLog: log)
-        let surface = FakeNookSurface()
-        let coordinator = makeCoordinator(modules: [a], surface: surface)
-        coordinator.registerGlobalHotkey()  // initial registration (start()'s job)
-        coordinator.bindHotkeyRegistration()  // install the sink
-        let mintedAfterStart = coordinator.hotkeyController.carbonIDsMintedForTesting
+        try await PreferenceStoreTestIsolation.withIsolatedStore {
+            let log = ExpandLog()
+            let a = SpyModule(id: "A", expandLog: log)
+            let surface = FakeNookSurface()
+            let coordinator = makeCoordinator(modules: [a], surface: surface)
+            coordinator.registerGlobalHotkey()  // initial registration (start()'s job)
+            coordinator.bindHotkeyRegistration()  // install the sink
+            let mintedAfterStart = coordinator.hotkeyController.carbonIDsMintedForTesting
 
-        // Open the recorder - intent maps to `.suspended`; sink unregisters (no mint).
-        coordinator.appState.isRecordingHotkey = true
-        try await Task.sleep(nanoseconds: 30_000_000)
-        XCTAssertEqual(
-            coordinator.hotkeyController.carbonIDsMintedForTesting, mintedAfterStart,
-            "unregister mints nothing"
-        )
+            // Open the recorder - intent maps to `.suspended`; sink unregisters (no mint).
+            coordinator.appState.isRecordingHotkey = true
+            try await Task.sleep(nanoseconds: 30_000_000)
+            XCTAssertEqual(
+                coordinator.hotkeyController.carbonIDsMintedForTesting, mintedAfterStart,
+                "unregister mints nothing"
+            )
 
-        // User picks a new hotkey, then closes the recorder. Both publishes happen on
-        // the same runloop turn - the sink must fire exactly ONE register for the new
-        // hotkey, not one per upstream @Published change.
-        let newHotkey = NookHotkey(keyCode: 51, carbonModifiers: 4096 | 2048, keySymbol: "⌫")
-        coordinator.appState.replaceHotkey(newHotkey)
-        coordinator.appState.isRecordingHotkey = false
-        try await Task.sleep(nanoseconds: 30_000_000)
+            // User picks a new hotkey, then closes the recorder. Both publishes happen on
+            // the same runloop turn - the sink must fire exactly ONE register for the new
+            // hotkey, not one per upstream @Published change.
+            let newHotkey = NookHotkey(keyCode: 51, carbonModifiers: 4096 | 2048, keySymbol: "⌫")
+            coordinator.appState.replaceHotkey(newHotkey)
+            coordinator.appState.isRecordingHotkey = false
+            try await Task.sleep(nanoseconds: 30_000_000)
 
-        XCTAssertEqual(
-            coordinator.hotkeyController.carbonIDsMintedForTesting,
-            mintedAfterStart + 1,
-            "one register per user action, not one per upstream @Published change"
-        )
-        XCTAssertTrue(coordinator.hotkeyController.registeredIDsForTesting.contains(NookHotkeyIDs.toggle))
+            XCTAssertEqual(
+                coordinator.hotkeyController.carbonIDsMintedForTesting,
+                mintedAfterStart + 1,
+                "one register per user action, not one per upstream @Published change"
+            )
+            XCTAssertTrue(coordinator.hotkeyController.registeredIDsForTesting.contains(NookHotkeyIDs.toggle))
+        }
     }
 
     /// Recorder opened and then cancelled without changing the key collapses through

--- a/Tests/NookKitTests/NookPreferenceDefaultsTests.swift
+++ b/Tests/NookKitTests/NookPreferenceDefaultsTests.swift
@@ -16,35 +16,6 @@ import XCTest
 /// `@MainActor`: `AppState` / `AppCoordinator` are main-actor isolated.
 @MainActor
 final class NookPreferenceDefaultsTests: XCTestCase {
-    private let storeKeys = [
-        "opennook.appearance.v1",
-        "opennook.hotkey.v1",
-        "opennook.display.v1",
-    ]
-    private var savedDefaults: [String: Data] = [:]
-
-    // Snapshot + clear the framework's UserDefaults keys so each test starts from a
-    // known "nothing persisted" state, then restore whatever was there afterward.
-    override func setUp() {
-        super.setUp()
-        for key in storeKeys {
-            savedDefaults[key] = UserDefaults.standard.data(forKey: key)
-            UserDefaults.standard.removeObject(forKey: key)
-        }
-    }
-
-    override func tearDown() {
-        for key in storeKeys {
-            if let data = savedDefaults[key] {
-                UserDefaults.standard.set(data, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
-        }
-        savedDefaults.removeAll()
-        super.tearDown()
-    }
-
     private var customDefaults: NookPreferenceDefaults {
         NookPreferenceDefaults(
             appearance: NookAppearancePreferences(
@@ -62,54 +33,64 @@ final class NookPreferenceDefaultsTests: XCTestCase {
     /// The default bag reproduces the framework exactly, and both configuration structs
     /// default to it - so an unconfigured host behaves as before.
     func testDefaultsReproduceFramework() {
-        XCTAssertEqual(NookPreferenceDefaults.default, NookPreferenceDefaults())
-        XCTAssertEqual(NookPreferenceDefaults.default.appearance, .default)
-        XCTAssertEqual(NookPreferenceDefaults.default.hotkey, .default)
-        XCTAssertEqual(NookPreferenceDefaults.default.display, .default)
+        PreferenceStoreTestIsolation.withIsolatedStore {
+            XCTAssertEqual(NookPreferenceDefaults.default, NookPreferenceDefaults())
+            XCTAssertEqual(NookPreferenceDefaults.default.appearance, .default)
+            XCTAssertEqual(NookPreferenceDefaults.default.hotkey, .default)
+            XCTAssertEqual(NookPreferenceDefaults.default.display, .default)
 
-        XCTAssertEqual(NookConfiguration().preferenceDefaults, .default)
-        XCTAssertEqual(NookHostConfiguration().preferenceDefaults, .default)
+            XCTAssertEqual(NookConfiguration().preferenceDefaults, .default)
+            XCTAssertEqual(NookHostConfiguration().preferenceDefaults, .default)
+        }
     }
 
     /// With nothing persisted, `AppState` seeds from the host defaults.
     func testAppStateSeedsFromDefaultsWhenNothingPersisted() {
-        let appState = AppState(preferenceDefaults: customDefaults)
+        PreferenceStoreTestIsolation.withIsolatedStore {
+            let appState = AppState(preferenceDefaults: customDefaults)
 
-        XCTAssertEqual(appState.appearancePreferences, customDefaults.appearance)
-        XCTAssertEqual(appState.hotkey, customDefaults.hotkey)
-        XCTAssertEqual(appState.displayPreference, customDefaults.display)
+            XCTAssertEqual(appState.appearancePreferences, customDefaults.appearance)
+            XCTAssertEqual(appState.hotkey, customDefaults.hotkey)
+            XCTAssertEqual(appState.displayPreference, customDefaults.display)
+        }
     }
 
     /// `AppState()` (and a `.default` seed) still falls back to framework defaults.
     func testAppStateWithoutSeedUsesFrameworkDefaults() {
-        let appState = AppState()
+        PreferenceStoreTestIsolation.withIsolatedStore {
+            let appState = AppState()
 
-        XCTAssertEqual(appState.appearancePreferences, .default)
-        XCTAssertEqual(appState.hotkey, .default)
-        XCTAssertEqual(appState.displayPreference, .default)
+            XCTAssertEqual(appState.appearancePreferences, .default)
+            XCTAssertEqual(appState.hotkey, .default)
+            XCTAssertEqual(appState.displayPreference, .default)
+        }
     }
 
     /// A value the user has already persisted beats the host seed.
     func testPersistedValueBeatsSeed() {
-        let persisted = NookAppearancePreferences(chromePalette: .light)
-        NookAppearanceStore.save(persisted)
+        PreferenceStoreTestIsolation.withIsolatedStore {
+            let persisted = NookAppearancePreferences(chromePalette: .light)
+            NookAppearanceStore.save(persisted)
 
-        let appState = AppState(preferenceDefaults: customDefaults)
+            let appState = AppState(preferenceDefaults: customDefaults)
 
-        XCTAssertEqual(appState.appearancePreferences, persisted)
-        XCTAssertNotEqual(appState.appearancePreferences, customDefaults.appearance)
+            XCTAssertEqual(appState.appearancePreferences, persisted)
+            XCTAssertNotEqual(appState.appearancePreferences, customDefaults.appearance)
+        }
     }
 
     /// Seeding must not write the host defaults to `UserDefaults` - otherwise a later
     /// build couldn't revise them for users who never touched Settings.
     func testSeedIsNotPersisted() {
-        _ = AppState(preferenceDefaults: customDefaults)
+        PreferenceStoreTestIsolation.withIsolatedStore {
+            _ = AppState(preferenceDefaults: customDefaults)
 
-        for key in storeKeys {
-            XCTAssertNil(
-                UserDefaults.standard.data(forKey: key),
-                "Seeding wrote \(key) to UserDefaults; it should stay a pure fallback."
-            )
+            for key in PreferenceStoreTestIsolation.storeKeys {
+                XCTAssertNil(
+                    UserDefaults.standard.data(forKey: key),
+                    "Seeding wrote \(key) to UserDefaults; it should stay a pure fallback."
+                )
+            }
         }
     }
 
@@ -117,20 +98,22 @@ final class NookPreferenceDefaultsTests: XCTestCase {
     /// the chrome's first paint uses - so a host's launch presentation is honored before
     /// any user interaction.
     func testSeededPresentationReachesSurface() {
-        let seeded = AppState(
-            preferenceDefaults: NookPreferenceDefaults(
-                appearance: NookAppearancePreferences(presentation: .floating)
+        PreferenceStoreTestIsolation.withIsolatedStore {
+            let seeded = AppState(
+                preferenceDefaults: NookPreferenceDefaults(
+                    appearance: NookAppearancePreferences(presentation: .floating)
+                )
             )
-        )
-        let surface = FakeNookSurface()
-        let coordinator = AppCoordinator(
-            appState: seeded,
-            moduleHost: ModuleHost(configuration: NookConfiguration()),
-            surface: surface
-        )
+            let surface = FakeNookSurface()
+            let coordinator = AppCoordinator(
+                appState: seeded,
+                moduleHost: ModuleHost(configuration: NookConfiguration()),
+                surface: surface
+            )
 
-        coordinator.syncNotchBackdrop()
+            coordinator.syncNotchBackdrop()
 
-        XCTAssertEqual(surface.presentation, .floating)
+            XCTAssertEqual(surface.presentation, .floating)
+        }
     }
 }

--- a/Tests/NookKitTests/PreferenceStoreTestIsolation.swift
+++ b/Tests/NookKitTests/PreferenceStoreTestIsolation.swift
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Glendon Chin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy is included at /LICENSE in the repository root.
+
+import Foundation
+
+/// Serializes access to the process-global `opennook.*` preference keys while tests run
+/// with `swift test --parallel`. Without this, one test's persisted values leak into
+/// another test's launch-seed assertions.
+enum PreferenceStoreTestIsolation {
+    static let storeKeys = [
+        "opennook.appearance.v1",
+        "opennook.hotkey.v1",
+        "opennook.display.v1",
+    ]
+
+    private static let lock = NSLock()
+
+    static func withIsolatedStore<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var saved: [String: Data] = [:]
+        for key in storeKeys {
+            saved[key] = UserDefaults.standard.data(forKey: key)
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        defer {
+            for key in storeKeys {
+                if let data = saved[key] {
+                    UserDefaults.standard.set(data, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+
+        return try body()
+    }
+
+    static func withIsolatedStore<T>(_ body: () async throws -> T) async rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var saved: [String: Data] = [:]
+        for key in storeKeys {
+            saved[key] = UserDefaults.standard.data(forKey: key)
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        defer {
+            for key in storeKeys {
+                if let data = saved[key] {
+                    UserDefaults.standard.set(data, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+
+        return try await body()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `release.yml` triggered on `v*.*.*` tags: validates CHANGELOG, builds DocC, publishes GitHub Release with notes + docs zip.
- Add `Scripts/validate-release-changelog.sh` and `Scripts/extract-changelog-section.sh` for local preview.
- Document the tag workflow in `Scripts/README.md`.

Dependabot security updates were enabled separately via repo settings (no code change).

## Test plan
- [x] `./Scripts/validate-release-changelog.sh v0.3.1`
- [x] `./Scripts/validate-release-changelog.sh v9.9.9` fails as expected
- [ ] CI green on PR