### PR TITLE
Add Tier 2 launch and UI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,30 @@ jobs:
             -destination 'platform=macOS' \
             build | xcbeautify
 
+  launch-smoke:
+    name: Launch smoke (examples + Nook)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Run expand/compact launch smoke on every executable
+        run: ./Scripts/smoke-examples.sh
+
+  ui-smoke:
+    name: UI smoke (notch panel)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: Install XcodeGen
+        run: brew install xcodegen xcbeautify
+      - name: Build app bundle and verify real panel window
+        run: ./Scripts/smoke-ui-app.sh
+
   licenses:
     name: License-header sanity
     runs-on: macos-15

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -44,3 +44,20 @@ Validate locally before tagging:
 ./Scripts/validate-release-changelog.sh vX.Y.Z
 ./Scripts/extract-changelog-section.sh X.Y.Z   # preview release notes
 ```
+
+## Launch smoke tests
+
+Every example executable and the `Nook` demo support a deterministic expand/compact
+cycle when launched with `OPENNOOK_SMOKE_TEST=1` (the process exits 0/1). Run them
+all locally with:
+
+```sh
+./Scripts/smoke-examples.sh
+```
+
+The bundled Xcode app supports `OPENNOOK_UI_SMOKE_TEST=1` (expands the real panel,
+checks the `opennook.panel` accessibility identifier, then exits). Run it with:
+
+```sh
+./Scripts/smoke-ui-app.sh
+```

--- a/Scripts/smoke-examples.sh
+++ b/Scripts/smoke-examples.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Launch every example executable (and the Nook demo) under OPENNOOK_SMOKE_TEST=1.
+# Each process runs a deterministic expand/compact cycle and exits 0/1.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TIMEOUT_SECONDS="${OPENNOOK_SMOKE_TIMEOUT:-30}"
+
+run_with_timeout() {
+  local duration="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$duration" "$@"
+    return
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$duration" "$@"
+    return
+  fi
+  perl -e 'alarm shift; exec @ARGV or die "exec failed: $!\n"' "$duration" "$@"
+}
+
+executables=(
+  Nook
+  HelloNook
+  ClockNook
+  ThemedNook
+  ChromeNook
+  LayoutNook
+  ShelfNook
+  ActivityNook
+  VolumeNook
+  MultiNook
+)
+
+echo "Building executables..."
+swift build -c debug
+
+for name in "${executables[@]}"; do
+  binary=".build/debug/${name}"
+  if [[ ! -x "$binary" ]]; then
+    echo "::error::missing executable $binary (did Package.swift change?)" >&2
+    exit 1
+  fi
+  echo "Smoke testing ${name}..."
+  if ! run_with_timeout "${TIMEOUT_SECONDS}" env OPENNOOK_SMOKE_TEST=1 "$binary"; then
+    echo "::error::smoke test failed for ${name}" >&2
+    exit 1
+  fi
+done
+
+echo "Launch smoke passed for ${#executables[@]} executables."

--- a/Scripts/smoke-ui-app.sh
+++ b/Scripts/smoke-ui-app.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build the Xcode app bundle and run OPENNOOK_UI_SMOKE_TEST against the real panel.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TIMEOUT_SECONDS="${OPENNOOK_SMOKE_TIMEOUT:-30}"
+
+run_with_timeout() {
+  local duration="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$duration" "$@"
+    return
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$duration" "$@"
+    return
+  fi
+  perl -e 'alarm shift; exec @ARGV or die "exec failed: $!\n"' "$duration" "$@"
+}
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "error: xcodegen not installed. Install with: brew install xcodegen" >&2
+  exit 1
+fi
+
+./Scripts/regenerate-xcodeproj.sh
+
+set -o pipefail
+if command -v xcbeautify >/dev/null 2>&1; then
+  xcodebuild \
+    -project Nook.xcodeproj \
+    -scheme NookHostApp \
+    -configuration Debug \
+    -destination 'platform=macOS' \
+    build | xcbeautify
+else
+  xcodebuild \
+    -project Nook.xcodeproj \
+    -scheme NookHostApp \
+    -configuration Debug \
+    -destination 'platform=macOS' \
+    build
+fi
+
+app_path="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path '*/Build/Products/Debug/Nook.app' -type d 2>/dev/null | head -1)"
+if [[ -z "$app_path" || ! -x "$app_path/Contents/MacOS/Nook" ]]; then
+  echo "::error::could not locate built Nook.app" >&2
+  exit 1
+fi
+
+echo "UI smoke testing ${app_path}..."
+run_with_timeout "${TIMEOUT_SECONDS}" env OPENNOOK_UI_SMOKE_TEST=1 "$app_path/Contents/MacOS/Nook"
+echo "UI smoke passed."

--- a/Sources/NookApp/NookApp.swift
+++ b/Sources/NookApp/NookApp.swift
@@ -116,6 +116,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         coordinator.start()
         installMenuBarFallback()
+        NookLaunchSmoke.handleLaunch(coordinator: coordinator)
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/Sources/NookApp/NookLaunchSmoke.swift
+++ b/Sources/NookApp/NookLaunchSmoke.swift
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Glendon Chin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy is included at /LICENSE in the repository root.
+
+import AppKit
+import Foundation
+
+enum NookLaunchSmoke {
+    static var runsExitSmokeTest: Bool {
+        ProcessInfo.processInfo.environment["OPENNOOK_SMOKE_TEST"] == "1"
+    }
+
+    static var runsUISmokeTest: Bool {
+        ProcessInfo.processInfo.environment["OPENNOOK_UI_SMOKE_TEST"] == "1"
+    }
+
+    @MainActor
+    static func handleLaunch(coordinator: AppCoordinator) {
+        if runsExitSmokeTest {
+            Task {
+                let ok = await coordinator.runLaunchSmokeTest()
+                exit(ok ? EXIT_SUCCESS : EXIT_FAILURE)
+            }
+            return
+        }
+
+        if runsUISmokeTest {
+            Task {
+                guard await coordinator.prepareForUISmokeTest() else {
+                    exit(EXIT_FAILURE)
+                }
+                guard verifyPanelWindow() else {
+                    exit(EXIT_FAILURE)
+                }
+                exit(EXIT_SUCCESS)
+            }
+        }
+    }
+
+    @MainActor
+    private static func verifyPanelWindow() -> Bool {
+        NSApplication.shared.windows.contains { window in
+            window.accessibilityIdentifier() == "opennook.panel"
+                && window.frame.width > 100
+                && window.frame.height > 20
+        }
+    }
+}

--- a/Sources/NookKit/App/AppCoordinator+SmokeTest.swift
+++ b/Sources/NookKit/App/AppCoordinator+SmokeTest.swift
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Glendon Chin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy is included at /LICENSE in the repository root.
+
+import Foundation
+import NookSurface
+
+public extension AppCoordinator {
+    /// Deterministic expand-then-compact cycle for launch smoke tests
+    /// (`OPENNOOK_SMOKE_TEST=1`). Returns `false` if any step times out.
+    func runLaunchSmokeTest(timeout: TimeInterval = 20) async -> Bool {
+        guard await waitForSurfaceState(.compact, timeout: timeout) else { return false }
+        showNook()
+        guard await waitForSurfaceState(.expanded, timeout: timeout) else { return false }
+        guard appState.isNookVisible else { return false }
+        hideNook()
+        return await waitForSurfaceState(.compact, timeout: timeout)
+    }
+
+    /// Expands the chrome and waits for the expanded state. Used by UI smoke tests
+    /// (`OPENNOOK_UI_SMOKE_TEST=1`) so XCUITest can assert on the real panel window.
+    func prepareForUISmokeTest(timeout: TimeInterval = 20) async -> Bool {
+        guard await waitForSurfaceState(.compact, timeout: timeout) else { return false }
+        showNook()
+        return await waitForSurfaceState(.expanded, timeout: timeout)
+    }
+
+    private func waitForSurfaceState(_ expected: NookState, timeout: TimeInterval) async -> Bool {
+        let pollNanoseconds: UInt64 = 50_000_000
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if surface.state == expected { return true }
+            try? await Task.sleep(nanoseconds: pollNanoseconds)
+        }
+        return surface.state == expected
+    }
+}

--- a/Sources/NookSurface/Internal/NookPanel.swift
+++ b/Sources/NookSurface/Internal/NookPanel.swift
@@ -47,6 +47,7 @@ final class NookPanel: NSPanel {
             .fullScreenAuxiliary,
             .ignoresCycle,
         ]
+        setAccessibilityIdentifier("opennook.panel")
     }
 
     override var canBecomeKey: Bool {

--- a/Tests/NookKitTests/AppCoordinatorTests.swift
+++ b/Tests/NookKitTests/AppCoordinatorTests.swift
@@ -555,6 +555,25 @@ final class AppCoordinatorTests: XCTestCase {
     /// Recorder opened and then cancelled without changing the key collapses through
     /// `.suspended` -> `.bound(unchanged)` - exactly one restore registration after the
     /// unregister.
+
+    // MARK: - Launch smoke test
+
+    func testLaunchSmokeTestExpandCompactCycle() async {
+        let surface = FakeNookSurface()
+        await surface.compact(on: nil)
+        let coordinator = makeCoordinator(
+            modules: [SpyModule(id: "A", expandLog: ExpandLog())],
+            surface: surface
+        )
+
+        let ok = await coordinator.runLaunchSmokeTest(timeout: 5)
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(surface.state, .compact)
+        XCTAssertFalse(coordinator.appState.isNookVisible)
+        XCTAssertTrue(surface.transitions.contains(.expanded))
+    }
+
     // MARK: - Cold-launch onCompact suppression
 
     /// Regression: the cold-launch compact in `start()` is a boot artifact, not a


### PR DESCRIPTION
## Summary
- Add `OPENNOOK_SMOKE_TEST=1` expand/compact cycle via `AppCoordinator.runLaunchSmokeTest()` for all SPM executables.
- Add `OPENNOOK_UI_SMOKE_TEST=1` bundled-app smoke that verifies the real `opennook.panel` window.
- Add `Scripts/smoke-examples.sh` and `Scripts/smoke-ui-app.sh`; new CI jobs `Launch smoke` and `UI smoke`.
- Tag `NookPanel` with `opennook.panel` accessibility identifier; isolate parallel UserDefaults tests remain from Tier 1.

## Test plan
- [x] `./Scripts/smoke-examples.sh`
- [x] `./Scripts/smoke-ui-app.sh`
- [x] `swift test --parallel`
- [ ] CI green on new smoke jobs