### PR TITLE
Settings: hide the panel scroll indicator

### DIFF
--- a/Sources/NookKit/App/Views/Settings/SettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// into one scrolling stack. Each section's content is its own file under `Views/Settings/`.
 ///
 /// Layout is deliberately flat: section label, then content, on one shared left margin
-/// (aligned with the top bar via `\.nookContentInsets`), separated by whitespace only - 
+/// (aligned with the top bar via `\.nookContentInsets`), separated by whitespace only,
 /// no card fills, no rules.
 struct SettingsView: View {
     @ObservedObject var appState: AppState
@@ -74,7 +74,9 @@ struct SettingsView: View {
                         SettingActionLine(
                             icon: appState.keepNookOpen ? "pin.fill" : "pin",
                             title: "Stay expanded",
-                            detail: appState.keepNookOpen ? "On — nook stays open after hover ends" : "Off — closes when the pointer leaves",
+                            detail: appState.keepNookOpen
+                                ? "On — nook stays open after hover ends"
+                                : "Off — closes when the pointer leaves",
                             accent: chromeInteractionAccent,
                             action: onToggleKeepOpen
                         )

--- a/Sources/NookKit/App/Views/Settings/SettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsView.swift
@@ -55,7 +55,7 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: true) {
+        ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 16) {
                 section("Appearance") {
                     NookAppearanceSettingsSection(appState: appState)


### PR DESCRIPTION
The Settings panel showed a vertical scroll indicator. Hide it so the panel reads cleaner; it still scrolls by trackpad and wheel.