### PR TITLE
Route framework chrome styling through typography and metrics tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,31 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `NookChromeTypography` - a host-tunable token type for the chrome's own fonts
-  (top bar, compact pill, status banner). Set via `NookConfiguration.typography`;
-  defaults reproduce the framework exactly, and the resolved `fontDesign` still
-  cascades over the roles. Restyles chrome text without forking, the typography
-  counterpart to the existing color (`NookResolvedTheme`) and layout
-  (`NookChromeMetrics`) seams.
+- `NookChromeTypography` - a host-tunable token type for the framework's own
+  fonts. Set via `NookConfiguration.typography`; defaults reproduce the framework
+  exactly, and the resolved `fontDesign` still cascades over the roles. Restyles
+  framework text without forking, the typography counterpart to the existing color
+  (`NookResolvedTheme`) and layout (`NookChromeMetrics`) seams. Roles cover the
+  top bar, compact pill, and status banner, plus the placeholder home, the
+  built-in Settings panel, and the optional `NookComponents` add-ons.
 - `NookChromeMetrics` gained the element-level dimensions, corner radii, spacing,
-  and emphasis-opacity values that were previously baked into the chrome views
-  (header icons, the leading brand mark, the compact pill, and the status
-  banner). All new fields default to today's values, so the change is additive
-  and non-breaking. Migrating the views to read these tokens means a host can now
-  restyle the top bar, compact pill, and banner through public API only.
+  and emphasis-opacity values that were previously baked into the framework views -
+  the chrome (header icons, leading brand mark, compact pill, status banner), the
+  placeholder home, the Settings panel (rows, pickers, the shortcut key cap, the
+  accent swatches, the disclosure section), and the `NookComponents` shelf,
+  activity card, and volume glyph. All new fields default to today's values, so
+  the change is additive and non-breaking.
 
 ### Changed
 
-- The chrome views (top bar, header icons, compact pill, status banner) now read
-  every font, size, radius, spacing, and opacity from `NookChromeTypography` /
-  `NookChromeMetrics` instead of inline literals. No visual change at the
-  defaults. The built-in Settings panel and `NookComponents` keep their current
-  styling; tokenizing those is a follow-up.
+- The framework views now read every font, size, radius, spacing, and opacity from
+  `NookChromeTypography` / `NookChromeMetrics` instead of inline literals - the
+  chrome (top bar, header icons, compact pill, status banner), the placeholder
+  home, the built-in Settings panel, and the `NookComponents` add-ons. No visual
+  change at the defaults; a host can now restyle any of these surfaces through
+  public API only. (A few intentionally-structural literals stay inline: motion
+  spring/offset magnitudes, the breadcrumb gradient mask, the fixed severity and
+  destructive-action colors, and zero-floor spacers.)
 
 ## [0.3.1] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `NookChromeTypography` - a host-tunable token type for the chrome's own fonts
+  (top bar, compact pill, status banner). Set via `NookConfiguration.typography`;
+  defaults reproduce the framework exactly, and the resolved `fontDesign` still
+  cascades over the roles. Restyles chrome text without forking, the typography
+  counterpart to the existing color (`NookResolvedTheme`) and layout
+  (`NookChromeMetrics`) seams.
+- `NookChromeMetrics` gained the element-level dimensions, corner radii, spacing,
+  and emphasis-opacity values that were previously baked into the chrome views
+  (header icons, the leading brand mark, the compact pill, and the status
+  banner). All new fields default to today's values, so the change is additive
+  and non-breaking. Migrating the views to read these tokens means a host can now
+  restyle the top bar, compact pill, and banner through public API only.
+
+### Changed
+
+- The chrome views (top bar, header icons, compact pill, status banner) now read
+  every font, size, radius, spacing, and opacity from `NookChromeTypography` /
+  `NookChromeMetrics` instead of inline literals. No visual change at the
+  defaults. The built-in Settings panel and `NookComponents` keep their current
+  styling; tokenizing those is a follow-up.
+
 ## [0.3.1] - 2026-06-12
 
 ### Fixed

--- a/Examples/MultiNook/main.swift
+++ b/Examples/MultiNook/main.swift
@@ -8,8 +8,9 @@
 // MultiNook - one host process, several interchangeable notch apps.
 //
 // A NookHostConfiguration registers a set of modules; the host shows one at a time and
-// the user switches between them through the switcher strip at the top of the expanded
-// surface, or with the module-cycle shortcut. Run with `swift run MultiNook`.
+// the user switches between them from the Modules menu-bar section (the default
+// `moduleSwitcherPlacement`), or with the module-cycle shortcut. See the placement
+// options near the bottom of this file. Run with `swift run MultiNook`.
 
 import NookApp
 import SwiftUI

--- a/Sources/NookComponents/Activities/NookActivityHost.swift
+++ b/Sources/NookComponents/Activities/NookActivityHost.swift
@@ -45,33 +45,35 @@ public struct NookActivityHost<Content: View>: View {
 public struct NookActivityCard: View {
     private let activity: NookActivity
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     public init(activity: NookActivity) {
         self.activity = activity
     }
 
     public var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: metrics.activityCardSpacing) {
             if let systemImage = activity.systemImage {
                 Image(systemName: systemImage)
-                    .font(.system(size: 24, weight: .medium))
+                    .font(typography.activityIcon)
                     .foregroundStyle(activity.tint)
-                    .frame(width: 30)
+                    .frame(width: metrics.activityIconWidth)
             }
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: metrics.activityTextSpacing) {
                 Text(activity.title)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(typography.activityTitle)
                     .foregroundStyle(theme.primaryLabel)
                 if let subtitle = activity.subtitle {
                     Text(subtitle)
-                        .font(.system(size: 11))
+                        .font(typography.activitySubtitle)
                         .foregroundStyle(theme.secondaryLabel)
                 }
             }
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 16)
-        .padding(.horizontal, 8)
+        .padding(.vertical, metrics.activityCardVerticalPadding)
+        .padding(.horizontal, metrics.activityCardHorizontalPadding)
     }
 }

--- a/Sources/NookComponents/Shelf/NookShelfView.swift
+++ b/Sources/NookComponents/Shelf/NookShelfView.swift
@@ -21,6 +21,8 @@ import SwiftUI
 public struct NookShelfView: View {
     @ObservedObject private var store: ShelfStore
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     /// Optional "add files" action. When provided, the empty drop zone becomes
     /// click-to-import and a `+` button appears in the populated header, so picking
@@ -35,7 +37,7 @@ public struct NookShelfView: View {
     }
 
     public var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: metrics.shelfContentSpacing) {
             if store.items.isEmpty {
                 emptyState
             } else {
@@ -44,7 +46,7 @@ public struct NookShelfView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 6)
+        .padding(.vertical, metrics.shelfRootVerticalPadding)
     }
 
     @ViewBuilder
@@ -61,27 +63,30 @@ public struct NookShelfView: View {
     }
 
     private var dropZone: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: metrics.shelfContentSpacing) {
             Image(systemName: "tray.and.arrow.down")
-                .font(.system(size: 24, weight: .light))
+                .font(typography.shelfDropZoneIcon)
                 .foregroundStyle(theme.tertiaryLabel)
             Text(onImport == nil ? "Drop files onto the notch to shelve them" : "Drop files here, or click to import")
-                .font(.system(size: 11))
+                .font(typography.shelfCaption)
                 .foregroundStyle(theme.tertiaryLabel)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 28)
+        .padding(.vertical, metrics.shelfDropZoneVerticalPadding)
         .contentShape(Rectangle())
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(theme.subtleStroke, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+            RoundedRectangle(cornerRadius: metrics.shelfDropZoneCornerRadius, style: .continuous)
+                .strokeBorder(
+                    theme.subtleStroke,
+                    style: StrokeStyle(lineWidth: metrics.shelfDropZoneStrokeWidth, dash: [4, 3])
+                )
         )
     }
 
     private var header: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: metrics.shelfHeaderSpacing) {
             Text("^[\(store.items.count) file](inflect: true)")
-                .font(.system(size: 11, weight: .medium))
+                .font(typography.shelfHeaderLabel)
                 .foregroundStyle(theme.secondaryLabel)
             Spacer(minLength: 0)
             if let onImport {
@@ -89,27 +94,27 @@ public struct NookShelfView: View {
                     Image(systemName: "plus")
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 11, weight: .medium))
+                .font(typography.shelfHeaderLabel)
                 .foregroundStyle(theme.tertiaryLabel)
                 .help("Import files")
             }
             Button("Clear") { store.clear() }
                 .buttonStyle(.plain)
-                .font(.system(size: 11))
+                .font(typography.shelfCaption)
                 .foregroundStyle(theme.tertiaryLabel)
         }
     }
 
     private var shelfRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
+            HStack(spacing: metrics.shelfContentSpacing) {
                 ForEach(store.items) { item in
                     ShelfItemChip(item: item, theme: theme) {
                         store.remove(item)
                     }
                 }
             }
-            .padding(.vertical, 2)
+            .padding(.vertical, metrics.shelfRowVerticalPadding)
         }
     }
 }
@@ -120,21 +125,23 @@ private struct ShelfItemChip: View {
     let theme: NookResolvedTheme
     let onRemove: () -> Void
 
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
     @State private var isHovered = false
 
     var body: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: metrics.shelfChipSpacing) {
             icon
             Text(item.displayName)
-                .font(.system(size: 10, weight: .medium))
+                .font(typography.shelfChipLabel)
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .foregroundStyle(theme.secondaryLabel)
         }
-        .frame(width: 72)
-        .padding(8)
+        .frame(width: metrics.shelfChipWidth)
+        .padding(metrics.shelfChipPadding)
         .background(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
+            RoundedRectangle(cornerRadius: metrics.shelfChipCornerRadius, style: .continuous)
                 .fill(theme.subtleFill)
         )
         .overlay(alignment: .topTrailing) {
@@ -159,19 +166,19 @@ private struct ShelfItemChip: View {
         if let fileIcon = item.withResolvedURL({ NSWorkspace.shared.icon(forFile: $0.path) }) {
             Image(nsImage: fileIcon)
                 .resizable()
-                .frame(width: 34, height: 34)
+                .frame(width: metrics.shelfIconSize, height: metrics.shelfIconSize)
         } else {
             Image(systemName: "questionmark.square.dashed")
-                .font(.system(size: 30, weight: .light))
+                .font(typography.shelfFallbackGlyph)
                 .foregroundStyle(theme.tertiaryLabel)
-                .frame(width: 34, height: 34)
+                .frame(width: metrics.shelfIconSize, height: metrics.shelfIconSize)
         }
     }
 
     private var removeButton: some View {
         Button(action: onRemove) {
             Image(systemName: "xmark.circle.fill")
-                .font(.system(size: 13))
+                .font(typography.shelfRemoveGlyph)
                 .foregroundStyle(theme.secondaryLabel)
                 .background(Circle().fill(theme.subtleFill))
         }

--- a/Sources/NookComponents/Volume/NookVolumeIndicator.swift
+++ b/Sources/NookComponents/Volume/NookVolumeIndicator.swift
@@ -47,10 +47,10 @@ public struct NookVolumeIndicator: View {
     public static func symbolName(volume: Double, isMuted: Bool) -> String {
         if isMuted { return "speaker.slash.fill" }
         switch volume {
-        case ..<0.01: return "speaker.fill"
-        case ..<0.34: return "speaker.wave.1.fill"
-        case ..<0.67: return "speaker.wave.2.fill"
-        default: return "speaker.wave.3.fill"
+            case ..<0.01: return "speaker.fill"
+            case ..<0.34: return "speaker.wave.1.fill"
+            case ..<0.67: return "speaker.wave.2.fill"
+            default: return "speaker.wave.3.fill"
         }
     }
 }

--- a/Sources/NookComponents/Volume/NookVolumeIndicator.swift
+++ b/Sources/NookComponents/Volume/NookVolumeIndicator.swift
@@ -23,6 +23,8 @@ import SwiftUI
 public struct NookVolumeIndicator: View {
     @ObservedObject private var observer: SystemVolumeObserver
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     public init(observer: SystemVolumeObserver) {
         self.observer = observer
@@ -30,9 +32,9 @@ public struct NookVolumeIndicator: View {
 
     public var body: some View {
         Image(systemName: Self.symbolName(volume: observer.volume, isMuted: observer.isMuted))
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(theme.primaryLabel.opacity(0.85))
-            .frame(width: 24, height: 24)
+            .font(typography.volumeGlyph)
+            .foregroundStyle(theme.primaryLabel.opacity(metrics.volumeGlyphOpacity))
+            .frame(width: metrics.compactSlotSize, height: metrics.compactSlotSize)
             .accessibilityLabel(
                 observer.isMuted
                     ? "Volume muted"

--- a/Sources/NookKit/App/NookChromeMetrics.swift
+++ b/Sources/NookKit/App/NookChromeMetrics.swift
@@ -143,6 +143,188 @@ public struct NookChromeMetrics: Sendable, Equatable {
     /// Line width of the banner outline. Default `0.5`.
     public var bannerStrokeWidth: CGFloat
 
+    // MARK: - Components (opt-in NookComponents add-ons)
+
+    /// Spacing inside the file shelf's stacks (root column, drop zone, item row). Default `8`.
+    public var shelfContentSpacing: CGFloat
+
+    /// Outer vertical padding of the file shelf surface. Default `6`.
+    public var shelfRootVerticalPadding: CGFloat
+
+    /// Vertical padding that gives the empty drop zone its height. Default `28`.
+    public var shelfDropZoneVerticalPadding: CGFloat
+
+    /// Corner radius of the empty drop zone's dashed well. Default `12`.
+    public var shelfDropZoneCornerRadius: CGFloat
+
+    /// Line width of the drop zone's dashed border. Default `1`.
+    public var shelfDropZoneStrokeWidth: CGFloat
+
+    /// Spacing in the populated shelf header (count / import / clear). Default `10`.
+    public var shelfHeaderSpacing: CGFloat
+
+    /// Spacing inside a shelf item chip (icon over filename). Default `4`.
+    public var shelfChipSpacing: CGFloat
+
+    /// Fixed width of a shelf item chip. Default `72`.
+    public var shelfChipWidth: CGFloat
+
+    /// Inner padding of a shelf item chip. Default `8`.
+    public var shelfChipPadding: CGFloat
+
+    /// Corner radius of a shelf item chip. Default `10`.
+    public var shelfChipCornerRadius: CGFloat
+
+    /// Square size of a shelf item's file icon. Default `34`.
+    public var shelfIconSize: CGFloat
+
+    /// Vertical padding around the horizontal shelf row. Default `2`.
+    public var shelfRowVerticalPadding: CGFloat
+
+    /// Spacing between the activity card's icon and its text column. Default `12`.
+    public var activityCardSpacing: CGFloat
+
+    /// Fixed width reserved for the activity card's leading icon. Default `30`.
+    public var activityIconWidth: CGFloat
+
+    /// Spacing between the activity card's title and subtitle. Default `2`.
+    public var activityTextSpacing: CGFloat
+
+    /// Vertical padding of the activity card. Default `16`.
+    public var activityCardVerticalPadding: CGFloat
+
+    /// Horizontal padding of the activity card. Default `8`.
+    public var activityCardHorizontalPadding: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for the ambient volume glyph.
+    /// Default `0.85`.
+    public var volumeGlyphOpacity: CGFloat
+
+    // MARK: - Placeholder home
+
+    /// Spacing between the placeholder home's mark, title, and body. Default `10`.
+    public var placeholderStackSpacing: CGFloat
+
+    /// Point size of the placeholder home's brand mark. Default `28`.
+    public var placeholderMarkSize: CGFloat
+
+    /// Stroke width of the placeholder home's brand mark. Default `2`.
+    public var placeholderMarkStrokeWidth: CGFloat
+
+    /// Outer vertical padding of the placeholder home. Default `40`.
+    public var placeholderVerticalPadding: CGFloat
+
+    // MARK: - Settings panel
+
+    /// Spacing between top-level settings sections. Default `16`.
+    public var settingsSectionSpacing: CGFloat
+
+    /// Spacing between rows within a settings group. Default `12`.
+    public var settingsGroupSpacing: CGFloat
+
+    /// Horizontal spacing between a settings row's icon and its text. Default `10`.
+    public var settingsRowSpacing: CGFloat
+
+    /// Vertical spacing between blocks within a settings section. Default `10`.
+    public var settingsBlockSpacing: CGFloat
+
+    /// Spacing between a settings field label and its control. Default `5`.
+    public var settingsFieldSpacing: CGFloat
+
+    /// Spacing between a settings row's title and its detail. Default `2`.
+    public var settingsTextSpacing: CGFloat
+
+    /// Spacing between the About card's name and tagline. Default `3`.
+    public var settingsAboutTextSpacing: CGFloat
+
+    /// Inline spacing inside settings rows (disclosure header, accent swatches, About name).
+    /// Default `6`.
+    public var settingsInlineSpacing: CGFloat
+
+    /// Bottom padding under the scrolling settings content. Default `14`.
+    public var settingsContentBottomPadding: CGFloat
+
+    /// Vertical padding of a tappable settings row. Default `4`.
+    public var settingsRowVerticalPadding: CGFloat
+
+    /// Fixed width of a settings row's leading icon gutter. Default `18`.
+    public var settingsIconWidth: CGFloat
+
+    /// Width of the disclosure chevron gutter (aligns with the top bar's icon column).
+    /// Default `24`.
+    public var settingsDisclosureGutter: CGFloat
+
+    /// Letter spacing applied to the uppercased settings section label. Default `0.42`.
+    public var settingsSectionLabelTracking: CGFloat
+
+    /// Width of the disclosure section's connector hairline. Default `1`.
+    public var settingsConnectorWidth: CGFloat
+
+    /// Opacity multiplier on the resolved subtle stroke for the connector hairline.
+    /// Default `0.5`.
+    public var settingsConnectorOpacity: CGFloat
+
+    /// Square size of an accent color swatch. Default `18`.
+    public var settingsAccentSwatchSize: CGFloat
+
+    /// Stroke width of the selected accent swatch's ring. Default `1.5`.
+    public var settingsAccentSwatchStrokeWidth: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for the selected swatch ring.
+    /// Default `0.85`.
+    public var settingsAccentSwatchSelectedOpacity: CGFloat
+
+    /// Minimum width of a shortcut key cap. Default `24`.
+    public var shortcutKeyCapMinWidth: CGFloat
+
+    /// Minimum height of a shortcut key cap. Default `22`.
+    public var shortcutKeyCapMinHeight: CGFloat
+
+    /// Corner radius of a shortcut key cap. Default `6`.
+    public var shortcutKeyCapCornerRadius: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for a shortcut key cap. Default `0.92`.
+    public var shortcutKeyCapLabelOpacity: CGFloat
+
+    /// Opacity multiplier on the resolved subtle fill for a shortcut key cap. Default `0.55`.
+    public var shortcutKeyCapFillOpacity: CGFloat
+
+    /// Opacity multiplier on the resolved subtle stroke for a shortcut key cap. Default `0.35`.
+    public var shortcutKeyCapStrokeOpacity: CGFloat
+
+    /// Stroke width of a shortcut key cap's outline. Default `1`.
+    public var shortcutKeyCapStrokeWidth: CGFloat
+
+    /// Horizontal spacing between the shortcut key caps in the show/hide row. Default `4`.
+    public var shortcutKeyCapSpacing: CGFloat
+
+    /// Horizontal padding of the hotkey "recording" capsule. Default `10`.
+    public var settingsRecordingHorizontalPadding: CGFloat
+
+    /// Minimum height of the hotkey "recording" capsule. Default `22`.
+    public var settingsRecordingMinHeight: CGFloat
+
+    /// Opacity multiplier on the resolved subtle fill for the recording capsule. Default `0.7`.
+    public var settingsRecordingFillOpacity: CGFloat
+
+    /// Opacity multiplier on the resolved accent for the recording capsule outline.
+    /// Default `0.6`.
+    public var settingsRecordingStrokeOpacity: CGFloat
+
+    /// Stroke width of the recording capsule's outline. Default `1`.
+    public var settingsRecordingStrokeWidth: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for emphasized settings titles
+    /// (shortcut row title, About product name). Default `0.95`.
+    public var settingsTitleEmphasisOpacity: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for the recording capsule label.
+    /// Default `0.9`.
+    public var settingsRecordingLabelOpacity: CGFloat
+
+    /// Vertical spacing between stacked hotkey-registration failure rows. Default `4`.
+    public var settingsFailureRowSpacing: CGFloat
+
     public init(
         edgePadding: CGFloat = NookLayout.edgePadding,
         expandedColumnSpacing: CGFloat = 8,
@@ -171,7 +353,63 @@ public struct NookChromeMetrics: Sendable, Equatable {
         bannerDismissButtonSize: CGFloat = 18,
         bannerMessageLabelOpacity: CGFloat = 0.92,
         bannerStrokeOpacity: CGFloat = 0.65,
-        bannerStrokeWidth: CGFloat = 0.5
+        bannerStrokeWidth: CGFloat = 0.5,
+        shelfContentSpacing: CGFloat = 8,
+        shelfRootVerticalPadding: CGFloat = 6,
+        shelfDropZoneVerticalPadding: CGFloat = 28,
+        shelfDropZoneCornerRadius: CGFloat = 12,
+        shelfDropZoneStrokeWidth: CGFloat = 1,
+        shelfHeaderSpacing: CGFloat = 10,
+        shelfChipSpacing: CGFloat = 4,
+        shelfChipWidth: CGFloat = 72,
+        shelfChipPadding: CGFloat = 8,
+        shelfChipCornerRadius: CGFloat = 10,
+        shelfIconSize: CGFloat = 34,
+        shelfRowVerticalPadding: CGFloat = 2,
+        activityCardSpacing: CGFloat = 12,
+        activityIconWidth: CGFloat = 30,
+        activityTextSpacing: CGFloat = 2,
+        activityCardVerticalPadding: CGFloat = 16,
+        activityCardHorizontalPadding: CGFloat = 8,
+        volumeGlyphOpacity: CGFloat = 0.85,
+        placeholderStackSpacing: CGFloat = 10,
+        placeholderMarkSize: CGFloat = 28,
+        placeholderMarkStrokeWidth: CGFloat = 2,
+        placeholderVerticalPadding: CGFloat = 40,
+        settingsSectionSpacing: CGFloat = 16,
+        settingsGroupSpacing: CGFloat = 12,
+        settingsRowSpacing: CGFloat = 10,
+        settingsBlockSpacing: CGFloat = 10,
+        settingsFieldSpacing: CGFloat = 5,
+        settingsTextSpacing: CGFloat = 2,
+        settingsAboutTextSpacing: CGFloat = 3,
+        settingsInlineSpacing: CGFloat = 6,
+        settingsContentBottomPadding: CGFloat = 14,
+        settingsRowVerticalPadding: CGFloat = 4,
+        settingsIconWidth: CGFloat = 18,
+        settingsDisclosureGutter: CGFloat = 24,
+        settingsSectionLabelTracking: CGFloat = 0.42,
+        settingsConnectorWidth: CGFloat = 1,
+        settingsConnectorOpacity: CGFloat = 0.5,
+        settingsAccentSwatchSize: CGFloat = 18,
+        settingsAccentSwatchStrokeWidth: CGFloat = 1.5,
+        settingsAccentSwatchSelectedOpacity: CGFloat = 0.85,
+        shortcutKeyCapMinWidth: CGFloat = 24,
+        shortcutKeyCapMinHeight: CGFloat = 22,
+        shortcutKeyCapCornerRadius: CGFloat = 6,
+        shortcutKeyCapLabelOpacity: CGFloat = 0.92,
+        shortcutKeyCapFillOpacity: CGFloat = 0.55,
+        shortcutKeyCapStrokeOpacity: CGFloat = 0.35,
+        shortcutKeyCapStrokeWidth: CGFloat = 1,
+        shortcutKeyCapSpacing: CGFloat = 4,
+        settingsRecordingHorizontalPadding: CGFloat = 10,
+        settingsRecordingMinHeight: CGFloat = 22,
+        settingsRecordingFillOpacity: CGFloat = 0.7,
+        settingsRecordingStrokeOpacity: CGFloat = 0.6,
+        settingsRecordingStrokeWidth: CGFloat = 1,
+        settingsTitleEmphasisOpacity: CGFloat = 0.95,
+        settingsRecordingLabelOpacity: CGFloat = 0.9,
+        settingsFailureRowSpacing: CGFloat = 4
     ) {
         self.edgePadding = edgePadding
         self.expandedColumnSpacing = expandedColumnSpacing
@@ -201,6 +439,62 @@ public struct NookChromeMetrics: Sendable, Equatable {
         self.bannerMessageLabelOpacity = bannerMessageLabelOpacity
         self.bannerStrokeOpacity = bannerStrokeOpacity
         self.bannerStrokeWidth = bannerStrokeWidth
+        self.shelfContentSpacing = shelfContentSpacing
+        self.shelfRootVerticalPadding = shelfRootVerticalPadding
+        self.shelfDropZoneVerticalPadding = shelfDropZoneVerticalPadding
+        self.shelfDropZoneCornerRadius = shelfDropZoneCornerRadius
+        self.shelfDropZoneStrokeWidth = shelfDropZoneStrokeWidth
+        self.shelfHeaderSpacing = shelfHeaderSpacing
+        self.shelfChipSpacing = shelfChipSpacing
+        self.shelfChipWidth = shelfChipWidth
+        self.shelfChipPadding = shelfChipPadding
+        self.shelfChipCornerRadius = shelfChipCornerRadius
+        self.shelfIconSize = shelfIconSize
+        self.shelfRowVerticalPadding = shelfRowVerticalPadding
+        self.activityCardSpacing = activityCardSpacing
+        self.activityIconWidth = activityIconWidth
+        self.activityTextSpacing = activityTextSpacing
+        self.activityCardVerticalPadding = activityCardVerticalPadding
+        self.activityCardHorizontalPadding = activityCardHorizontalPadding
+        self.volumeGlyphOpacity = volumeGlyphOpacity
+        self.placeholderStackSpacing = placeholderStackSpacing
+        self.placeholderMarkSize = placeholderMarkSize
+        self.placeholderMarkStrokeWidth = placeholderMarkStrokeWidth
+        self.placeholderVerticalPadding = placeholderVerticalPadding
+        self.settingsSectionSpacing = settingsSectionSpacing
+        self.settingsGroupSpacing = settingsGroupSpacing
+        self.settingsRowSpacing = settingsRowSpacing
+        self.settingsBlockSpacing = settingsBlockSpacing
+        self.settingsFieldSpacing = settingsFieldSpacing
+        self.settingsTextSpacing = settingsTextSpacing
+        self.settingsAboutTextSpacing = settingsAboutTextSpacing
+        self.settingsInlineSpacing = settingsInlineSpacing
+        self.settingsContentBottomPadding = settingsContentBottomPadding
+        self.settingsRowVerticalPadding = settingsRowVerticalPadding
+        self.settingsIconWidth = settingsIconWidth
+        self.settingsDisclosureGutter = settingsDisclosureGutter
+        self.settingsSectionLabelTracking = settingsSectionLabelTracking
+        self.settingsConnectorWidth = settingsConnectorWidth
+        self.settingsConnectorOpacity = settingsConnectorOpacity
+        self.settingsAccentSwatchSize = settingsAccentSwatchSize
+        self.settingsAccentSwatchStrokeWidth = settingsAccentSwatchStrokeWidth
+        self.settingsAccentSwatchSelectedOpacity = settingsAccentSwatchSelectedOpacity
+        self.shortcutKeyCapMinWidth = shortcutKeyCapMinWidth
+        self.shortcutKeyCapMinHeight = shortcutKeyCapMinHeight
+        self.shortcutKeyCapCornerRadius = shortcutKeyCapCornerRadius
+        self.shortcutKeyCapLabelOpacity = shortcutKeyCapLabelOpacity
+        self.shortcutKeyCapFillOpacity = shortcutKeyCapFillOpacity
+        self.shortcutKeyCapStrokeOpacity = shortcutKeyCapStrokeOpacity
+        self.shortcutKeyCapStrokeWidth = shortcutKeyCapStrokeWidth
+        self.shortcutKeyCapSpacing = shortcutKeyCapSpacing
+        self.settingsRecordingHorizontalPadding = settingsRecordingHorizontalPadding
+        self.settingsRecordingMinHeight = settingsRecordingMinHeight
+        self.settingsRecordingFillOpacity = settingsRecordingFillOpacity
+        self.settingsRecordingStrokeOpacity = settingsRecordingStrokeOpacity
+        self.settingsRecordingStrokeWidth = settingsRecordingStrokeWidth
+        self.settingsTitleEmphasisOpacity = settingsTitleEmphasisOpacity
+        self.settingsRecordingLabelOpacity = settingsRecordingLabelOpacity
+        self.settingsFailureRowSpacing = settingsFailureRowSpacing
     }
 
     /// The framework-default metrics - reproduces today's layout.

--- a/Sources/NookKit/App/NookChromeMetrics.swift
+++ b/Sources/NookKit/App/NookChromeMetrics.swift
@@ -505,9 +505,9 @@ private struct NookChromeMetricsKey: EnvironmentKey {
     static let defaultValue: NookChromeMetrics = .default
 }
 
-public extension EnvironmentValues {
+extension EnvironmentValues {
     /// Host-tunable chrome layout metrics. See ``NookChromeMetrics``.
-    var nookChromeMetrics: NookChromeMetrics {
+    public var nookChromeMetrics: NookChromeMetrics {
         get { self[NookChromeMetricsKey.self] }
         set { self[NookChromeMetricsKey.self] = newValue }
     }

--- a/Sources/NookKit/App/NookChromeMetrics.swift
+++ b/Sources/NookKit/App/NookChromeMetrics.swift
@@ -7,14 +7,27 @@
 
 import SwiftUI
 
-/// Host-tunable layout metrics for the framework chrome - the few fixed point values
-/// that were previously baked into the views as `NookLayout` constants. Defaults
-/// reproduce today's layout exactly.
+/// Host-tunable point values for the framework chrome - the element sizes, corner radii,
+/// inter-element spacing, and the opacity multipliers layered on the resolved palette that
+/// were previously baked into the chrome views. Defaults reproduce today's layout exactly.
+///
+/// Colors come from ``NookResolvedTheme`` and fonts from ``NookChromeTypography``; this
+/// type covers the dimensional and emphasis constants that sit between them. To restyle a
+/// single value, copy ``default`` and set the field - every property is a `public var`:
+///
+/// ```swift
+/// var metrics = NookChromeMetrics.default
+/// metrics.headerIconCornerRadius = 10
+/// configuration.metrics = metrics
+/// ```
 ///
 /// Set via ``NookConfiguration/metrics``. The values reach the expanded surface, the top
-/// bar, and the compact slots through the chrome environment
+/// bar, the status banner, and the compact slots through the chrome environment
 /// (``EnvironmentValues/nookChromeMetrics``).
 public struct NookChromeMetrics: Sendable, Equatable {
+
+    // MARK: - Expanded surface
+
     /// Inset between the expanded panel edge and its content (and the basis for the
     /// re-injected safe-area insets). Default `8`.
     ///
@@ -26,26 +39,168 @@ public struct NookChromeMetrics: Sendable, Equatable {
     /// `Examples/LayoutNook/main.swift`.
     public var edgePadding: CGFloat
 
-    /// Square size of each compact pill slot (the glyphs flanking the notch). Default `24`.
-    public var compactSlotSize: CGFloat
+    /// Vertical gap between the top bar, the status banner, and the home/settings surface
+    /// in the expanded column. Default `8`.
+    public var expandedColumnSpacing: CGFloat
+
+    // MARK: - Top bar
+
+    /// Fixed height of the top bar's icon row. Default `24`.
+    public var topBarHeight: CGFloat
+
+    /// Horizontal gap between the top bar's leading content, the flexible spacer, and the
+    /// trailing cluster. Default `8`.
+    public var topBarItemSpacing: CGFloat
+
+    /// Gap between the leading brand mark / icon and its title (and the same gap inside the
+    /// in-surface module switcher's label). Default `6`.
+    public var leadingClusterSpacing: CGFloat
+
+    /// Gap between the trailing host items, the keep-open lock, and the gear. Tighter than
+    /// the leading cluster. Default `4`.
+    public var trailingClusterSpacing: CGFloat
 
     /// Maximum width of the top bar's module-breadcrumb label before it fades - capped to
     /// the leading pre-notch region so it doesn't split across the notch. Default `140`.
     public var breadcrumbMaxWidth: CGFloat
 
-    /// Fixed height of the top bar's icon row. Default `24`.
-    public var topBarHeight: CGFloat
+    // MARK: - Header icons (lock / gear / home glyphs)
+
+    /// Square size of each header icon's hit and visual frame. Default `24`.
+    public var headerIconSize: CGFloat
+
+    /// Corner radius of a header icon's hover background fill and outline. Default `7`.
+    public var headerIconCornerRadius: CGFloat
+
+    /// Line width of a header icon's hover outline. Default `1`.
+    public var headerIconStrokeWidth: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for a hovered header icon's glyph.
+    /// Default `0.92`.
+    public var headerIconHoverLabelOpacity: CGFloat
+
+    // MARK: - Leading brand mark
+
+    /// Point size and bounding frame of the top bar's leading-cluster brand mark glyph
+    /// (used when no host `leadingIcon` is set). Default `11`.
+    public var brandMarkSize: CGFloat
+
+    /// Stroke width of the leading-cluster brand mark glyph. Default `1.1`.
+    public var brandMarkStrokeWidth: CGFloat
+
+    /// Opacity multiplier on the resolved secondary label for the leading brand mark.
+    /// Default `0.92`.
+    public var brandMarkOpacity: CGFloat
+
+    // MARK: - Compact pill
+
+    /// Square size of each compact pill slot (the glyphs flanking the notch). Default `24`.
+    public var compactSlotSize: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for the default compact leading
+    /// glyph. Default `0.88`.
+    public var compactLeadingGlyphOpacity: CGFloat
+
+    /// Point size of the default compact trailing mark glyph. Distinct from
+    /// ``compactSlotSize`` (the slot frame around it). Default `11`.
+    public var compactTrailingMarkSize: CGFloat
+
+    /// Stroke width of the default compact trailing mark glyph. Default `1.1`.
+    public var compactTrailingMarkStrokeWidth: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for the default compact trailing
+    /// mark. Default `0.82`.
+    public var compactTrailingMarkOpacity: CGFloat
+
+    // MARK: - Status banner
+
+    /// Item spacing inside the status banner row (severity glyph / message / dismiss).
+    /// Default `8`.
+    public var bannerRowSpacing: CGFloat
+
+    /// Corner radius of the status banner's background fill and outline. Default `10`.
+    public var bannerCornerRadius: CGFloat
+
+    /// Horizontal padding inside the status banner. Default `10`.
+    public var bannerContentHorizontalPadding: CGFloat
+
+    /// Vertical padding inside the status banner. Default `7`.
+    public var bannerContentVerticalPadding: CGFloat
+
+    /// Top nudge aligning the banner severity glyph with the first line of message text.
+    /// Default `1`.
+    public var bannerSeverityGlyphTopInset: CGFloat
+
+    /// Square size of the banner's dismiss button hit frame. Default `18`.
+    public var bannerDismissButtonSize: CGFloat
+
+    /// Opacity multiplier on the resolved primary label for the banner message. Default `0.92`.
+    public var bannerMessageLabelOpacity: CGFloat
+
+    /// Opacity multiplier on the resolved subtle stroke for the banner outline. Default `0.65`.
+    public var bannerStrokeOpacity: CGFloat
+
+    /// Line width of the banner outline. Default `0.5`.
+    public var bannerStrokeWidth: CGFloat
 
     public init(
         edgePadding: CGFloat = NookLayout.edgePadding,
-        compactSlotSize: CGFloat = NookLayout.compactSlotSize,
+        expandedColumnSpacing: CGFloat = 8,
+        topBarHeight: CGFloat = NookLayout.topBarHeight,
+        topBarItemSpacing: CGFloat = 8,
+        leadingClusterSpacing: CGFloat = 6,
+        trailingClusterSpacing: CGFloat = 4,
         breadcrumbMaxWidth: CGFloat = NookLayout.breadcrumbMaxWidth,
-        topBarHeight: CGFloat = NookLayout.topBarHeight
+        headerIconSize: CGFloat = 24,
+        headerIconCornerRadius: CGFloat = 7,
+        headerIconStrokeWidth: CGFloat = 1,
+        headerIconHoverLabelOpacity: CGFloat = 0.92,
+        brandMarkSize: CGFloat = 11,
+        brandMarkStrokeWidth: CGFloat = 1.1,
+        brandMarkOpacity: CGFloat = 0.92,
+        compactSlotSize: CGFloat = NookLayout.compactSlotSize,
+        compactLeadingGlyphOpacity: CGFloat = 0.88,
+        compactTrailingMarkSize: CGFloat = 11,
+        compactTrailingMarkStrokeWidth: CGFloat = 1.1,
+        compactTrailingMarkOpacity: CGFloat = 0.82,
+        bannerRowSpacing: CGFloat = 8,
+        bannerCornerRadius: CGFloat = 10,
+        bannerContentHorizontalPadding: CGFloat = 10,
+        bannerContentVerticalPadding: CGFloat = 7,
+        bannerSeverityGlyphTopInset: CGFloat = 1,
+        bannerDismissButtonSize: CGFloat = 18,
+        bannerMessageLabelOpacity: CGFloat = 0.92,
+        bannerStrokeOpacity: CGFloat = 0.65,
+        bannerStrokeWidth: CGFloat = 0.5
     ) {
         self.edgePadding = edgePadding
-        self.compactSlotSize = compactSlotSize
-        self.breadcrumbMaxWidth = breadcrumbMaxWidth
+        self.expandedColumnSpacing = expandedColumnSpacing
         self.topBarHeight = topBarHeight
+        self.topBarItemSpacing = topBarItemSpacing
+        self.leadingClusterSpacing = leadingClusterSpacing
+        self.trailingClusterSpacing = trailingClusterSpacing
+        self.breadcrumbMaxWidth = breadcrumbMaxWidth
+        self.headerIconSize = headerIconSize
+        self.headerIconCornerRadius = headerIconCornerRadius
+        self.headerIconStrokeWidth = headerIconStrokeWidth
+        self.headerIconHoverLabelOpacity = headerIconHoverLabelOpacity
+        self.brandMarkSize = brandMarkSize
+        self.brandMarkStrokeWidth = brandMarkStrokeWidth
+        self.brandMarkOpacity = brandMarkOpacity
+        self.compactSlotSize = compactSlotSize
+        self.compactLeadingGlyphOpacity = compactLeadingGlyphOpacity
+        self.compactTrailingMarkSize = compactTrailingMarkSize
+        self.compactTrailingMarkStrokeWidth = compactTrailingMarkStrokeWidth
+        self.compactTrailingMarkOpacity = compactTrailingMarkOpacity
+        self.bannerRowSpacing = bannerRowSpacing
+        self.bannerCornerRadius = bannerCornerRadius
+        self.bannerContentHorizontalPadding = bannerContentHorizontalPadding
+        self.bannerContentVerticalPadding = bannerContentVerticalPadding
+        self.bannerSeverityGlyphTopInset = bannerSeverityGlyphTopInset
+        self.bannerDismissButtonSize = bannerDismissButtonSize
+        self.bannerMessageLabelOpacity = bannerMessageLabelOpacity
+        self.bannerStrokeOpacity = bannerStrokeOpacity
+        self.bannerStrokeWidth = bannerStrokeWidth
     }
 
     /// The framework-default metrics - reproduces today's layout.

--- a/Sources/NookKit/App/NookChromeTypography.swift
+++ b/Sources/NookKit/App/NookChromeTypography.swift
@@ -208,9 +208,9 @@ private struct NookChromeTypographyKey: EnvironmentKey {
     static let defaultValue: NookChromeTypography = .default
 }
 
-public extension EnvironmentValues {
+extension EnvironmentValues {
     /// Host-tunable chrome typography. See ``NookChromeTypography``.
-    var nookChromeTypography: NookChromeTypography {
+    public var nookChromeTypography: NookChromeTypography {
         get { self[NookChromeTypographyKey.self] }
         set { self[NookChromeTypographyKey.self] = newValue }
     }

--- a/Sources/NookKit/App/NookChromeTypography.swift
+++ b/Sources/NookKit/App/NookChromeTypography.swift
@@ -7,21 +7,24 @@
 
 import SwiftUI
 
-/// Host-tunable fonts for the framework chrome's own text and glyphs - the top bar, the
-/// compact pill, and the transient status banner. Defaults reproduce today's typography
-/// exactly.
+/// Host-tunable fonts for the framework's own text and glyphs - the chrome (top bar,
+/// compact pill, status banner) and the optional ``NookComponents`` add-ons. Defaults
+/// reproduce today's typography exactly.
 ///
 /// Each role is a `Font`; the framework defaults are built with `.system(size:weight:)`
 /// and carry no explicit design, so the chrome's ``NookResolvedTheme/fontDesign`` still
 /// cascades over them (applied once on the expanded surface). Supply a role with an
 /// explicit design only to override that for a single element.
 ///
-/// This restyles the *chrome's* type, not host-supplied content - a registered home
+/// This restyles the *framework's* type, not host-supplied content - a registered home
 /// view, custom Settings, or trailing items control their own fonts.
 ///
 /// Set via ``NookConfiguration/typography``. The values reach the views through the chrome
 /// environment (``EnvironmentValues/nookChromeTypography``).
 public struct NookChromeTypography: Sendable, Equatable {
+
+    // MARK: - Top bar
+
     /// The lock / gear / home glyphs on the top bar (the `HeaderIcon` views).
     public var headerIcon: Font
 
@@ -35,8 +38,12 @@ public struct NookChromeTypography: Sendable, Equatable {
     /// The `chevron.down` disclosure glyph on the in-surface module switcher.
     public var switcherChevron: Font
 
+    // MARK: - Compact pill
+
     /// The default compact pill's leading glyph (the `house` symbol).
     public var compactLeadingGlyph: Font
+
+    // MARK: - Status banner
 
     /// The status banner's leading severity glyph.
     public var bannerSeverityGlyph: Font
@@ -47,6 +54,84 @@ public struct NookChromeTypography: Sendable, Equatable {
     /// The status banner's trailing dismiss (`xmark`) glyph.
     public var bannerDismissGlyph: Font
 
+    // MARK: - Components (opt-in NookComponents add-ons)
+
+    /// The file shelf's empty-state tray glyph.
+    public var shelfDropZoneIcon: Font
+
+    /// The file shelf's regular-weight secondary text (drop-zone caption, Clear button).
+    public var shelfCaption: Font
+
+    /// The file shelf header's medium-weight controls (file count, import `+`).
+    public var shelfHeaderLabel: Font
+
+    /// A shelf item chip's filename label.
+    public var shelfChipLabel: Font
+
+    /// The shelf item chip's fallback glyph when no file icon is available.
+    public var shelfFallbackGlyph: Font
+
+    /// The shelf item chip's hover-revealed remove glyph.
+    public var shelfRemoveGlyph: Font
+
+    /// The activity card's leading icon.
+    public var activityIcon: Font
+
+    /// The activity card's title.
+    public var activityTitle: Font
+
+    /// The activity card's subtitle.
+    public var activitySubtitle: Font
+
+    /// The ambient volume indicator's speaker glyph.
+    public var volumeGlyph: Font
+
+    // MARK: - Placeholder home
+
+    /// The default placeholder home view's title.
+    public var placeholderTitle: Font
+
+    /// The default placeholder home view's body text.
+    public var placeholderBody: Font
+
+    // MARK: - Settings panel
+
+    /// A settings section header label (rendered uppercased).
+    public var settingsSectionLabel: Font
+
+    /// A small settings hint or failure line (shortcut subtitle, registration failure).
+    public var settingsHint: Font
+
+    /// Settings caption / description text (picker descriptions, About tagline).
+    public var settingsCaption: Font
+
+    /// The About card's monospaced version string.
+    public var settingsVersionLabel: Font
+
+    /// A settings field label above a picker, slider, or swatch row.
+    public var settingsFieldLabel: Font
+
+    /// The trailing disclosure chevron on a Data command row.
+    public var settingsCommandChevron: Font
+
+    /// A settings row's detail / subtitle text.
+    public var settingsRowDetail: Font
+
+    /// A settings row's medium-weight title (shortcut row, failure name, key cap).
+    public var settingsRowTitle: Font
+
+    /// A settings emphasis glyph or label (row icons, About product name).
+    public var settingsEmphasis: Font
+
+    /// A settings command row's title (action line, data command).
+    public var settingsCommandTitle: Font
+
+    /// A settings command row's leading icon.
+    public var settingsCommandIcon: Font
+
+    /// The collapsible settings section's disclosure chevron.
+    public var settingsDisclosureChevron: Font
+
     public init(
         headerIcon: Font = .system(size: 11, weight: .semibold),
         topBarLabel: Font = .system(size: 11, weight: .regular),
@@ -55,7 +140,31 @@ public struct NookChromeTypography: Sendable, Equatable {
         compactLeadingGlyph: Font = .system(size: 10, weight: .semibold),
         bannerSeverityGlyph: Font = .system(size: 11, weight: .semibold),
         bannerMessage: Font = .system(size: 10.5, weight: .medium),
-        bannerDismissGlyph: Font = .system(size: 9, weight: .bold)
+        bannerDismissGlyph: Font = .system(size: 9, weight: .bold),
+        shelfDropZoneIcon: Font = .system(size: 24, weight: .light),
+        shelfCaption: Font = .system(size: 11),
+        shelfHeaderLabel: Font = .system(size: 11, weight: .medium),
+        shelfChipLabel: Font = .system(size: 10, weight: .medium),
+        shelfFallbackGlyph: Font = .system(size: 30, weight: .light),
+        shelfRemoveGlyph: Font = .system(size: 13),
+        activityIcon: Font = .system(size: 24, weight: .medium),
+        activityTitle: Font = .system(size: 13, weight: .semibold),
+        activitySubtitle: Font = .system(size: 11),
+        volumeGlyph: Font = .system(size: 11, weight: .semibold),
+        placeholderTitle: Font = .system(size: 14, weight: .medium),
+        placeholderBody: Font = .system(size: 11, weight: .regular),
+        settingsSectionLabel: Font = .system(size: 9, weight: .semibold),
+        settingsHint: Font = .system(size: 9, weight: .regular),
+        settingsCaption: Font = .system(size: 10, weight: .regular),
+        settingsVersionLabel: Font = .system(size: 10, weight: .regular, design: .monospaced),
+        settingsFieldLabel: Font = .system(size: 10, weight: .medium),
+        settingsCommandChevron: Font = .system(size: 10, weight: .bold),
+        settingsRowDetail: Font = .system(size: 11, weight: .regular),
+        settingsRowTitle: Font = .system(size: 11, weight: .medium),
+        settingsEmphasis: Font = .system(size: 11, weight: .semibold),
+        settingsCommandTitle: Font = .system(size: 12, weight: .regular),
+        settingsCommandIcon: Font = .system(size: 12, weight: .semibold),
+        settingsDisclosureChevron: Font = .system(size: 8, weight: .bold)
     ) {
         self.headerIcon = headerIcon
         self.topBarLabel = topBarLabel
@@ -65,6 +174,30 @@ public struct NookChromeTypography: Sendable, Equatable {
         self.bannerSeverityGlyph = bannerSeverityGlyph
         self.bannerMessage = bannerMessage
         self.bannerDismissGlyph = bannerDismissGlyph
+        self.shelfDropZoneIcon = shelfDropZoneIcon
+        self.shelfCaption = shelfCaption
+        self.shelfHeaderLabel = shelfHeaderLabel
+        self.shelfChipLabel = shelfChipLabel
+        self.shelfFallbackGlyph = shelfFallbackGlyph
+        self.shelfRemoveGlyph = shelfRemoveGlyph
+        self.activityIcon = activityIcon
+        self.activityTitle = activityTitle
+        self.activitySubtitle = activitySubtitle
+        self.volumeGlyph = volumeGlyph
+        self.placeholderTitle = placeholderTitle
+        self.placeholderBody = placeholderBody
+        self.settingsSectionLabel = settingsSectionLabel
+        self.settingsHint = settingsHint
+        self.settingsCaption = settingsCaption
+        self.settingsVersionLabel = settingsVersionLabel
+        self.settingsFieldLabel = settingsFieldLabel
+        self.settingsCommandChevron = settingsCommandChevron
+        self.settingsRowDetail = settingsRowDetail
+        self.settingsRowTitle = settingsRowTitle
+        self.settingsEmphasis = settingsEmphasis
+        self.settingsCommandTitle = settingsCommandTitle
+        self.settingsCommandIcon = settingsCommandIcon
+        self.settingsDisclosureChevron = settingsDisclosureChevron
     }
 
     /// The framework-default chrome typography - reproduces today's fonts.

--- a/Sources/NookKit/App/NookChromeTypography.swift
+++ b/Sources/NookKit/App/NookChromeTypography.swift
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Glendon Chin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy is included at /LICENSE in the repository root.
+
+import SwiftUI
+
+/// Host-tunable fonts for the framework chrome's own text and glyphs - the top bar, the
+/// compact pill, and the transient status banner. Defaults reproduce today's typography
+/// exactly.
+///
+/// Each role is a `Font`; the framework defaults are built with `.system(size:weight:)`
+/// and carry no explicit design, so the chrome's ``NookResolvedTheme/fontDesign`` still
+/// cascades over them (applied once on the expanded surface). Supply a role with an
+/// explicit design only to override that for a single element.
+///
+/// This restyles the *chrome's* type, not host-supplied content - a registered home
+/// view, custom Settings, or trailing items control their own fonts.
+///
+/// Set via ``NookConfiguration/typography``. The values reach the views through the chrome
+/// environment (``EnvironmentValues/nookChromeTypography``).
+public struct NookChromeTypography: Sendable, Equatable {
+    /// The lock / gear / home glyphs on the top bar (the `HeaderIcon` views).
+    public var headerIcon: Font
+
+    /// The leading-cluster title, the Settings and module breadcrumb labels, and the
+    /// module switcher's active-module label - the bar's regular-weight text.
+    public var topBarLabel: Font
+
+    /// The `chevron.right` separator drawn before a Settings or module breadcrumb.
+    public var breadcrumbChevron: Font
+
+    /// The `chevron.down` disclosure glyph on the in-surface module switcher.
+    public var switcherChevron: Font
+
+    /// The default compact pill's leading glyph (the `house` symbol).
+    public var compactLeadingGlyph: Font
+
+    /// The status banner's leading severity glyph.
+    public var bannerSeverityGlyph: Font
+
+    /// The status banner's message text.
+    public var bannerMessage: Font
+
+    /// The status banner's trailing dismiss (`xmark`) glyph.
+    public var bannerDismissGlyph: Font
+
+    public init(
+        headerIcon: Font = .system(size: 11, weight: .semibold),
+        topBarLabel: Font = .system(size: 11, weight: .regular),
+        breadcrumbChevron: Font = .system(size: 8, weight: .bold),
+        switcherChevron: Font = .system(size: 7, weight: .semibold),
+        compactLeadingGlyph: Font = .system(size: 10, weight: .semibold),
+        bannerSeverityGlyph: Font = .system(size: 11, weight: .semibold),
+        bannerMessage: Font = .system(size: 10.5, weight: .medium),
+        bannerDismissGlyph: Font = .system(size: 9, weight: .bold)
+    ) {
+        self.headerIcon = headerIcon
+        self.topBarLabel = topBarLabel
+        self.breadcrumbChevron = breadcrumbChevron
+        self.switcherChevron = switcherChevron
+        self.compactLeadingGlyph = compactLeadingGlyph
+        self.bannerSeverityGlyph = bannerSeverityGlyph
+        self.bannerMessage = bannerMessage
+        self.bannerDismissGlyph = bannerDismissGlyph
+    }
+
+    /// The framework-default chrome typography - reproduces today's fonts.
+    public static let `default` = NookChromeTypography()
+}
+
+private struct NookChromeTypographyKey: EnvironmentKey {
+    static let defaultValue: NookChromeTypography = .default
+}
+
+public extension EnvironmentValues {
+    /// Host-tunable chrome typography. See ``NookChromeTypography``.
+    var nookChromeTypography: NookChromeTypography {
+        get { self[NookChromeTypographyKey.self] }
+        set { self[NookChromeTypographyKey.self] = newValue }
+    }
+}

--- a/Sources/NookKit/App/NookConfiguration.swift
+++ b/Sources/NookKit/App/NookConfiguration.swift
@@ -98,6 +98,11 @@ public struct NookConfiguration: Sendable {
     /// to ``NookChromeMotion/default`` (today's springs). See ``NookChromeMotion``.
     public var motion: NookChromeMotion = .default
 
+    /// Host-tunable chrome typography (top-bar, compact-pill, and status-banner fonts).
+    /// Defaults to ``NookChromeTypography/default`` (today's fonts). Restyles the chrome's
+    /// own text, not host-supplied content. See ``NookChromeTypography``.
+    public var typography: NookChromeTypography = .default
+
     /// Host-product identity surfaced through the chrome - name, tagline, and brand mark
     /// (About card, show/hide hotkey label, menu-bar fallback, top-bar leading mark). On
     /// the single-module path this is forwarded onto the synthesized

--- a/Sources/NookKit/App/Views/Compact/CompactViews.swift
+++ b/Sources/NookKit/App/Views/Compact/CompactViews.swift
@@ -15,14 +15,15 @@ import SwiftUI
 /// apps register their own via ``NookConfiguration/setCompactLeading(_:)``.
 public struct NookCompactLeadingView: View {
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
     @Environment(\.nookChromeMetrics) private var metrics
 
     public init() {}
 
     public var body: some View {
         Image(systemName: "house")
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(theme.primaryLabel.opacity(0.88))
+            .font(typography.compactLeadingGlyph)
+            .foregroundStyle(theme.primaryLabel.opacity(metrics.compactLeadingGlyphOpacity))
             .frame(width: metrics.compactSlotSize, height: metrics.compactSlotSize)
     }
 }
@@ -36,9 +37,9 @@ public struct NookCompactTrailingView: View {
 
     public var body: some View {
         NookMarkView(
-            size: 11,
-            strokeWidth: 1.1,
-            color: theme.primaryLabel.opacity(0.82)
+            size: metrics.compactTrailingMarkSize,
+            strokeWidth: metrics.compactTrailingMarkStrokeWidth,
+            color: theme.primaryLabel.opacity(metrics.compactTrailingMarkOpacity)
         )
         .frame(width: metrics.compactSlotSize, height: metrics.compactSlotSize)
     }

--- a/Sources/NookKit/App/Views/ModuleRouterViews.swift
+++ b/Sources/NookKit/App/Views/ModuleRouterViews.swift
@@ -36,6 +36,7 @@ struct ModuleRouterExpandedView: View {
             labels: configuration.labels,
             metrics: configuration.metrics,
             motion: configuration.motion,
+            typography: configuration.typography,
             width: configuration.expandedWidth ?? NookLayout.width,
             // Only fold a switcher into the chrome when the host opted in; otherwise the
             // surface is untouched and switching lives in the menu bar / hotkeys.
@@ -88,8 +89,9 @@ struct ModuleRouterCompactView: View {
             content: content
         )
         // The compact slots render in their own view tree (not under NookExpandedView),
-        // so inject the metrics here too - the default compact glyphs read
-        // `compactSlotSize` from it.
+        // so inject the chrome metrics and typography here too - the default compact
+        // glyphs read `compactSlotSize` / `compactLeadingGlyph` from them.
         .environment(\.nookChromeMetrics, configuration.metrics)
+        .environment(\.nookChromeTypography, configuration.typography)
     }
 }

--- a/Sources/NookKit/App/Views/NookExpandedView.swift
+++ b/Sources/NookKit/App/Views/NookExpandedView.swift
@@ -77,8 +77,9 @@ public struct NookExpandedView: View {
         toggleKeepOpen: @escaping () -> Void,
         hide: @escaping () -> Void,
         resetAllSettings: @escaping () -> Void,
-        theme: @escaping @Sendable @MainActor (AppState) -> NookResolvedTheme
-            = { NookResolvedTheme.live(appState: $0) },
+        theme: @escaping @Sendable @MainActor (AppState) -> NookResolvedTheme = {
+            NookResolvedTheme.live(appState: $0)
+        },
         home: @escaping @Sendable @MainActor () -> AnyView = { AnyView(NookPlaceholderHomeView()) },
         settings: (@Sendable @MainActor () -> AnyView)? = nil,
         topBar: NookTopBarConfiguration = .default,
@@ -131,28 +132,28 @@ public struct NookExpandedView: View {
             .frame(width: width)
             .padding(metrics.edgePadding)
             .environment(\.nookResolvedTheme, resolvedTheme)
-        .environment(\.nookChromeLabels, labels)
-        .environment(\.nookChromeMetrics, metrics)
-        .environment(\.nookChromeMotion, motion)
-        .environment(\.nookChromeTypography, typography)
-        .environment(\.appServices, services)
-        // Expose `AppState` to the host-registered `home` surface so it can observe
-        // chrome-level state (e.g. `isDragInFlight`) without each closure needing a
-        // bespoke parameter.
-        .environmentObject(appState)
-        // The nook lives on a `.nonactivatingPanel` so opening it never steals focus from
-        // the user's editor. Side effect: until the user clicks the surface, AppKit
-        // desaturates accent-tinted controls. Forcing `.active` makes the chrome paint as
-        // if focused without changing key-window behaviour.
-        .environment(\.controlActiveState, .active)
-        .tint(resolvedTheme.accent)
-        .fontDesign(resolvedTheme.fontDesign)
-        .preferredColorScheme(appState.appearancePreferences.chromeColorSchemeOverride)
-        .onChange(of: appState.viewMode) { _ in
-            isHomeIconHovered = false
-        }
-        .onExitCommand(perform: hide)
-        .animation(motion.viewModeChange, value: appState.viewMode)
+            .environment(\.nookChromeLabels, labels)
+            .environment(\.nookChromeMetrics, metrics)
+            .environment(\.nookChromeMotion, motion)
+            .environment(\.nookChromeTypography, typography)
+            .environment(\.appServices, services)
+            // Expose `AppState` to the host-registered `home` surface so it can observe
+            // chrome-level state (e.g. `isDragInFlight`) without each closure needing a
+            // bespoke parameter.
+            .environmentObject(appState)
+            // The nook lives on a `.nonactivatingPanel` so opening it never steals focus from
+            // the user's editor. Side effect: until the user clicks the surface, AppKit
+            // desaturates accent-tinted controls. Forcing `.active` makes the chrome paint as
+            // if focused without changing key-window behaviour.
+            .environment(\.controlActiveState, .active)
+            .tint(resolvedTheme.accent)
+            .fontDesign(resolvedTheme.fontDesign)
+            .preferredColorScheme(appState.appearancePreferences.chromeColorSchemeOverride)
+            .onChange(of: appState.viewMode) { _ in
+                isHomeIconHovered = false
+            }
+            .onExitCommand(perform: hide)
+            .animation(motion.viewModeChange, value: appState.viewMode)
     }
 
     @ViewBuilder

--- a/Sources/NookKit/App/Views/NookExpandedView.swift
+++ b/Sources/NookKit/App/Views/NookExpandedView.swift
@@ -43,12 +43,14 @@ public struct NookExpandedView: View {
     /// visibility, Settings visibility. See ``NookTopBarConfiguration``.
     let topBar: NookTopBarConfiguration
 
-    /// Host-overridable chrome strings, layout metrics, and in-panel motion. Injected
-    /// into the environment for the top bar / banner to read. See ``NookChromeLabels`` /
-    /// ``NookChromeMetrics`` / ``NookChromeMotion``.
+    /// Host-overridable chrome strings, layout metrics, in-panel motion, and typography.
+    /// Injected into the environment for the top bar / banner to read. See
+    /// ``NookChromeLabels`` / ``NookChromeMetrics`` / ``NookChromeMotion`` /
+    /// ``NookChromeTypography``.
     let labels: NookChromeLabels
     let metrics: NookChromeMetrics
     let motion: NookChromeMotion
+    let typography: NookChromeTypography
 
     /// Fixed width for the expanded surface. Host apps set this through
     /// ``NookConfiguration/expandedWidth``; the default is ``NookLayout/width``.
@@ -83,6 +85,7 @@ public struct NookExpandedView: View {
         labels: NookChromeLabels = .default,
         metrics: NookChromeMetrics = .default,
         motion: NookChromeMotion = .default,
+        typography: NookChromeTypography = .default,
         width: CGFloat = NookLayout.width,
         moduleSwitcher: NookModuleSwitcher? = nil
     ) {
@@ -98,6 +101,7 @@ public struct NookExpandedView: View {
         self.labels = labels
         self.metrics = metrics
         self.motion = motion
+        self.typography = typography
         self.width = width
         self.moduleSwitcher = moduleSwitcher
     }
@@ -130,6 +134,7 @@ public struct NookExpandedView: View {
         .environment(\.nookChromeLabels, labels)
         .environment(\.nookChromeMetrics, metrics)
         .environment(\.nookChromeMotion, motion)
+        .environment(\.nookChromeTypography, typography)
         .environment(\.appServices, services)
         // Expose `AppState` to the host-registered `home` surface so it can observe
         // chrome-level state (e.g. `isDragInFlight`) without each closure needing a
@@ -152,7 +157,7 @@ public struct NookExpandedView: View {
 
     @ViewBuilder
     private var expandedColumn: some View {
-        let stack = VStack(alignment: .leading, spacing: 8) {
+        let stack = VStack(alignment: .leading, spacing: metrics.expandedColumnSpacing) {
             if topBar.showsTopBar {
                 topBarRow
 

--- a/Sources/NookKit/App/Views/NookPlaceholderHomeView.swift
+++ b/Sources/NookKit/App/Views/NookPlaceholderHomeView.swift
@@ -18,24 +18,26 @@ import SwiftUI
 /// configured theme automatically.
 public struct NookPlaceholderHomeView: View {
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     public init() {}
 
     public var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: metrics.placeholderStackSpacing) {
             NookMarkView(
-                size: 28,
-                strokeWidth: 2,
+                size: metrics.placeholderMarkSize,
+                strokeWidth: metrics.placeholderMarkStrokeWidth,
                 color: theme.secondaryLabel
             )
             Text("Nook")
-                .font(.system(size: 14, weight: .medium))
+                .font(typography.placeholderTitle)
                 .foregroundStyle(theme.primaryLabel)
             Text("Register your own view with NookConfiguration to start building.")
-                .font(.system(size: 11, weight: .regular))
+                .font(typography.placeholderBody)
                 .foregroundStyle(theme.tertiaryLabel)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 40)
+        .padding(.vertical, metrics.placeholderVerticalPadding)
     }
 }

--- a/Sources/NookKit/App/Views/NookTopBar.swift
+++ b/Sources/NookKit/App/Views/NookTopBar.swift
@@ -66,10 +66,10 @@ struct NookTopBar: View {
     var body: some View {
         Group {
             switch width {
-            case .contentColumn:
-                contentColumnBar
-            case .intrinsic:
-                intrinsicBar
+                case .contentColumn:
+                    contentColumnBar
+                case .intrinsic:
+                    intrinsicBar
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -130,7 +130,7 @@ struct NookTopBar: View {
                             stops: [
                                 .init(color: .black, location: 0),
                                 .init(color: .black, location: 0.5),
-                                .init(color: .clear, location: 1)
+                                .init(color: .clear, location: 1),
                             ],
                             startPoint: .leading,
                             endPoint: .trailing

--- a/Sources/NookKit/App/Views/NookTopBar.swift
+++ b/Sources/NookKit/App/Views/NookTopBar.swift
@@ -50,12 +50,14 @@ struct NookTopBar: View {
     /// by these values so host rows and the top bar share one horizontal gutter.
     @Environment(\.nookContentInsets) private var contentInsets
 
-    /// Host-overridable chrome strings, layout metrics, and in-panel motion (see
-    /// ``NookChromeLabels`` / ``NookChromeMetrics`` / ``NookChromeMotion``). Injected by
-    /// ``NookExpandedView``; default reproduces today's chrome.
+    /// Host-overridable chrome strings, layout metrics, in-panel motion, and typography
+    /// (see ``NookChromeLabels`` / ``NookChromeMetrics`` / ``NookChromeMotion`` /
+    /// ``NookChromeTypography``). Injected by ``NookExpandedView``; defaults reproduce
+    /// today's chrome.
     @Environment(\.nookChromeLabels) private var labels
     @Environment(\.nookChromeMetrics) private var metrics
     @Environment(\.nookChromeMotion) private var motion
+    @Environment(\.nookChromeTypography) private var typography
 
     /// Host branding - used for the leading-cluster brand mark when no `leadingIcon` is
     /// configured. Injected by the expanded router. See ``NookHostBranding``.
@@ -91,7 +93,7 @@ struct NookTopBar: View {
     }
 
     private var intrinsicBar: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: metrics.topBarItemSpacing) {
             leadingBarContent
             Spacer(minLength: 0)
             trailingCluster
@@ -100,26 +102,26 @@ struct NookTopBar: View {
     }
 
     private var leadingBarContent: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: metrics.topBarItemSpacing) {
             homeLeadingCluster
                 .fixedSize(horizontal: true, vertical: false)
                 .padding(.leading, contentInsets.leading)
 
             if appState.isSettingsView {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .bold))
+                    .font(typography.breadcrumbChevron)
                     .foregroundStyle(resolvedTheme.quaternaryLabel)
 
                 Text(labels.settingsBreadcrumb)
-                    .font(.system(size: 11, weight: .regular))
+                    .font(typography.topBarLabel)
                     .foregroundStyle(resolvedTheme.secondaryLabel)
             } else if let breadcrumb = appState.moduleBreadcrumb, !breadcrumb.isEmpty {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 8, weight: .bold))
+                    .font(typography.breadcrumbChevron)
                     .foregroundStyle(resolvedTheme.quaternaryLabel)
 
                 Text(breadcrumb)
-                    .font(.system(size: 11, weight: .regular))
+                    .font(typography.topBarLabel)
                     .foregroundStyle(resolvedTheme.secondaryLabel)
                     .lineLimit(1)
                     .frame(width: metrics.breadcrumbMaxWidth, alignment: .leading)
@@ -143,7 +145,7 @@ struct NookTopBar: View {
     }
 
     private var trailingCluster: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: metrics.trailingClusterSpacing) {
             if let trailingItems {
                 trailingItems()
             }
@@ -177,7 +179,7 @@ struct NookTopBar: View {
         .fixedSize(horizontal: true, vertical: false)
     }
 
-    /// On home the configured title stays visible next to its icon; in settings - 
+    /// On home the configured title stays visible next to its icon; in settings -
     /// or when a module has pushed a `moduleBreadcrumb` (a drilled-in product
     /// sub-context) - the label collapses until the user hovers the glyph, which
     /// doubles as the back control. Clicking it exits Settings or clears the
@@ -187,7 +189,7 @@ struct NookTopBar: View {
         let showPersistentHomeTitle = appState.isHomeView && !appState.isSettingsView && !hasBreadcrumb
         let title = leadingTitle(appState)
 
-        return HStack(spacing: 6) {
+        return HStack(spacing: metrics.leadingClusterSpacing) {
             if showPersistentHomeTitle, let moduleSwitcher {
                 // Multi-module host that opted into an in-surface switcher: the leading
                 // cluster IS the switcher (it replaces the plain title - no extra band,
@@ -204,14 +206,14 @@ struct NookTopBar: View {
                     StaticHeaderIcon(systemName: leadingIcon)
                 } else {
                     branding.markView(
-                        size: 11,
-                        strokeWidth: 1.1,
-                        color: resolvedTheme.secondaryLabel.opacity(0.92)
+                        size: metrics.brandMarkSize,
+                        strokeWidth: metrics.brandMarkStrokeWidth,
+                        color: resolvedTheme.secondaryLabel.opacity(metrics.brandMarkOpacity)
                     )
-                    .frame(width: 11, height: 11)
+                    .frame(width: metrics.brandMarkSize, height: metrics.brandMarkSize)
                 }
                 Text(title)
-                    .font(.system(size: 11, weight: .regular))
+                    .font(typography.topBarLabel)
                     .foregroundStyle(resolvedTheme.secondaryLabel)
                     .lineLimit(1)
             } else {
@@ -236,7 +238,7 @@ struct NookTopBar: View {
 
                 if isHomeIconHovered {
                     Text(title)
-                        .font(.system(size: 11, weight: .regular))
+                        .font(typography.topBarLabel)
                         .foregroundStyle(resolvedTheme.secondaryLabel)
                         .lineLimit(1)
                         .transition(
@@ -264,6 +266,9 @@ private struct ModuleSwitcherMenu: View {
     let theme: NookResolvedTheme
     let branding: NookHostBranding
 
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
+
     var body: some View {
         Menu {
             ForEach(switcher.modules) { descriptor in
@@ -280,14 +285,14 @@ private struct ModuleSwitcherMenu: View {
                 }
             }
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: metrics.leadingClusterSpacing) {
                 icon
                 Text(activeTitle)
-                    .font(.system(size: 11, weight: .regular))
+                    .font(typography.topBarLabel)
                     .foregroundStyle(theme.secondaryLabel)
                     .lineLimit(1)
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 7, weight: .semibold))
+                    .font(typography.switcherChevron)
                     .foregroundStyle(theme.tertiaryLabel)
             }
         }
@@ -306,11 +311,11 @@ private struct ModuleSwitcherMenu: View {
             StaticHeaderIcon(systemName: symbol)
         } else {
             branding.markView(
-                size: 11,
-                strokeWidth: 1.1,
-                color: theme.secondaryLabel.opacity(0.92)
+                size: metrics.brandMarkSize,
+                strokeWidth: metrics.brandMarkStrokeWidth,
+                color: theme.secondaryLabel.opacity(metrics.brandMarkOpacity)
             )
-            .frame(width: 11, height: 11)
+            .frame(width: metrics.brandMarkSize, height: metrics.brandMarkSize)
         }
     }
 }

--- a/Sources/NookKit/App/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/AppearanceSettingsView.swift
@@ -118,13 +118,13 @@ public struct NookAppearanceSettingsSection: View {
 
     private var surfaceStyleDescription: String {
         switch surfaceStyleBinding.wrappedValue {
-        case .solid:
-            return "Solid paints the chrome the same color as the notch — true black on dark, true white on light."
-        case .translucent:
-            return "Translucent shows the wallpaper through a frosted material."
-        case .liquidGlass:
-            return "Liquid Glass refracts the wallpaper through Apple's glass material on macOS 26, "
-                + "with a frosted-glass fallback on earlier versions."
+            case .solid:
+                return "Solid paints the chrome the same color as the notch — true black on dark, true white on light."
+            case .translucent:
+                return "Translucent shows the wallpaper through a frosted material."
+            case .liquidGlass:
+                return "Liquid Glass refracts the wallpaper through Apple's glass material on macOS 26, "
+                    + "with a frosted-glass fallback on earlier versions."
         }
     }
 
@@ -134,12 +134,12 @@ public struct NookAppearanceSettingsSection: View {
 
     private var presentationDescription: String {
         switch presentationBinding.wrappedValue {
-        case .auto:
-            return "Auto uses the notch shape on a notched display and a floating panel on any other."
-        case .notch:
-            return "Notch always uses the notch shape, even on a display without one."
-        case .floating:
-            return "Floating always shows a free-standing panel below the menu bar."
+            case .auto:
+                return "Auto uses the notch shape on a notched display and a floating panel on any other."
+            case .notch:
+                return "Notch always uses the notch shape, even on a display without one."
+            case .floating:
+                return "Floating always shows a free-standing panel below the menu bar."
         }
     }
 

--- a/Sources/NookKit/App/Views/Settings/AppearanceSettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/AppearanceSettingsView.swift
@@ -12,13 +12,15 @@ import SwiftUI
 public struct NookAppearanceSettingsSection: View {
     @ObservedObject public var appState: AppState
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     public init(appState: AppState) {
         self.appState = appState
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: metrics.settingsBlockSpacing) {
             labeledPicker(title: "Theme", accessibilityLabel: "Theme") {
                 Picker("Theme", selection: chromePaletteBinding) {
                     Text("Match Mac").tag(NookChromePalette.followSystem)
@@ -30,7 +32,7 @@ public struct NookAppearanceSettingsSection: View {
                 .controlSize(.small)
             }
 
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: metrics.settingsFieldSpacing) {
                 labeledPicker(title: "Surface", accessibilityLabel: "Chrome surface") {
                     Picker("Surface", selection: surfaceStyleBinding) {
                         Text("Solid").tag(NookSurfaceStyle.solid)
@@ -43,12 +45,12 @@ public struct NookAppearanceSettingsSection: View {
                 }
 
                 Text(surfaceStyleDescription)
-                    .font(.system(size: 10, weight: .regular))
+                    .font(typography.settingsCaption)
                     .foregroundStyle(theme.tertiaryLabel)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: metrics.settingsFieldSpacing) {
                 labeledPicker(title: "Layout", accessibilityLabel: "Chrome layout") {
                     Picker("Layout", selection: presentationBinding) {
                         Text("Auto").tag(NookPresentation.auto)
@@ -61,16 +63,16 @@ public struct NookAppearanceSettingsSection: View {
                 }
 
                 Text(presentationDescription)
-                    .font(.system(size: 10, weight: .regular))
+                    .font(typography.settingsCaption)
                     .foregroundStyle(theme.tertiaryLabel)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: metrics.settingsFieldSpacing) {
                 Text("Accent")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(typography.settingsFieldLabel)
                     .foregroundStyle(theme.secondaryLabel)
-                HStack(spacing: 6) {
+                HStack(spacing: metrics.settingsInlineSpacing) {
                     ForEach(NookAccentPreset.allCases) { preset in
                         Button {
                             var prefs = appState.appearancePreferences
@@ -79,14 +81,15 @@ public struct NookAppearanceSettingsSection: View {
                         } label: {
                             Circle()
                                 .fill(preset.color())
-                                .frame(width: 18, height: 18)
+                                .frame(
+                                    width: metrics.settingsAccentSwatchSize,
+                                    height: metrics.settingsAccentSwatchSize
+                                )
                                 .overlay(
                                     Circle()
                                         .stroke(
-                                            appState.appearancePreferences.accentPreset == preset
-                                                ? theme.primaryLabel.opacity(0.85)
-                                                : Color.clear,
-                                            lineWidth: 1.5
+                                            accentRingColor(for: preset),
+                                            lineWidth: metrics.settingsAccentSwatchStrokeWidth
                                         )
                                 )
                         }
@@ -97,15 +100,15 @@ public struct NookAppearanceSettingsSection: View {
             }
 
             if appState.appearancePreferences.surfaceStyle != .solid {
-                VStack(alignment: .leading, spacing: 5) {
+                VStack(alignment: .leading, spacing: metrics.settingsFieldSpacing) {
                     Text(strengthLabel)
-                        .font(.system(size: 10, weight: .medium))
+                        .font(typography.settingsFieldLabel)
                         .foregroundStyle(theme.secondaryLabel)
                     Slider(value: backdropStrengthBinding, in: 0.35...1)
                         .controlSize(.small)
                         .accessibilityLabel(strengthLabel)
                     Text("Lower shows more wallpaper through the chrome.")
-                        .font(.system(size: 10, weight: .regular))
+                        .font(typography.settingsCaption)
                         .foregroundStyle(theme.tertiaryLabel)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -120,7 +123,8 @@ public struct NookAppearanceSettingsSection: View {
         case .translucent:
             return "Translucent shows the wallpaper through a frosted material."
         case .liquidGlass:
-            return "Liquid Glass refracts the wallpaper through Apple's glass material on macOS 26, with a frosted-glass fallback on earlier versions."
+            return "Liquid Glass refracts the wallpaper through Apple's glass material on macOS 26, "
+                + "with a frosted-glass fallback on earlier versions."
         }
     }
 
@@ -140,14 +144,25 @@ public struct NookAppearanceSettingsSection: View {
     }
 
     @ViewBuilder
-    private func labeledPicker(title: String, accessibilityLabel: String, @ViewBuilder picker: () -> some View) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
+    private func labeledPicker(
+        title: String,
+        accessibilityLabel: String,
+        @ViewBuilder picker: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: metrics.settingsFieldSpacing) {
             Text(title)
-                .font(.system(size: 10, weight: .medium))
+                .font(typography.settingsFieldLabel)
                 .foregroundStyle(theme.secondaryLabel)
             picker()
                 .accessibilityLabel(accessibilityLabel)
         }
+    }
+
+    /// The selected accent swatch's ring color; clear for the unselected swatches.
+    private func accentRingColor(for preset: NookAccentPreset) -> Color {
+        appState.appearancePreferences.accentPreset == preset
+            ? theme.primaryLabel.opacity(metrics.settingsAccentSwatchSelectedOpacity)
+            : Color.clear
     }
 
     private var chromePaletteBinding: Binding<NookChromePalette> {

--- a/Sources/NookKit/App/Views/Settings/DisplaySettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/DisplaySettingsView.swift
@@ -57,16 +57,17 @@ struct DisplaySettingsSection: View {
 
     private var descriptionText: String {
         switch appState.displayPreference.mode {
-        case .builtIn:
-            return "The chrome stays on the built-in (notched) display."
-        case .main:
-            return "The chrome follows the display that currently hosts the menu bar."
-        case .specific:
-            let connected = appState.displayPreference.displayUUID
-                .map { uuid in displays.contains { $0.uuid == uuid } } ?? false
-            return connected
-                ? "The chrome is pinned to a specific display."
-                : "The chosen display isn't connected — using the built-in display until it returns."
+            case .builtIn:
+                return "The chrome stays on the built-in (notched) display."
+            case .main:
+                return "The chrome follows the display that currently hosts the menu bar."
+            case .specific:
+                let connected =
+                    appState.displayPreference.displayUUID
+                    .map { uuid in displays.contains { $0.uuid == uuid } } ?? false
+                return connected
+                    ? "The chrome is pinned to a specific display."
+                    : "The chosen display isn't connected — using the built-in display until it returns."
         }
     }
 
@@ -77,8 +78,9 @@ struct DisplaySettingsSection: View {
             (tag: Self.specificTagPrefix + display.uuid, label: display.name)
         }
         if appState.displayPreference.mode == .specific,
-           let uuid = appState.displayPreference.displayUUID,
-           !displays.contains(where: { $0.uuid == uuid }) {
+            let uuid = appState.displayPreference.displayUUID,
+            !displays.contains(where: { $0.uuid == uuid })
+        {
             options.append((tag: Self.specificTagPrefix + uuid, label: "Saved display (not connected)"))
         }
         return options
@@ -89,9 +91,9 @@ struct DisplaySettingsSection: View {
             get: {
                 let preference = appState.displayPreference
                 switch preference.mode {
-                case .builtIn: return Self.builtInTag
-                case .main: return Self.mainTag
-                case .specific: return Self.specificTagPrefix + (preference.displayUUID ?? "")
+                    case .builtIn: return Self.builtInTag
+                    case .main: return Self.mainTag
+                    case .specific: return Self.specificTagPrefix + (preference.displayUUID ?? "")
                 }
             },
             set: { tag in

--- a/Sources/NookKit/App/Views/Settings/DisplaySettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/DisplaySettingsView.swift
@@ -17,6 +17,8 @@ import SwiftUI
 struct DisplaySettingsSection: View {
     @ObservedObject var appState: AppState
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     @State private var displays: [NookScreenLocator.DisplayInfo] = NookScreenLocator.connectedDisplays()
 
@@ -25,7 +27,7 @@ struct DisplaySettingsSection: View {
     private static let specificTagPrefix = "uuid:"
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 5) {
+        VStack(alignment: .leading, spacing: metrics.settingsFieldSpacing) {
             Picker("Display", selection: selectionBinding) {
                 Text("Built-in display").tag(Self.builtInTag)
                 Text("Display with active menu bar").tag(Self.mainTag)
@@ -42,11 +44,13 @@ struct DisplaySettingsSection: View {
             .accessibilityLabel("Display")
 
             Text(descriptionText)
-                .font(.system(size: 10, weight: .regular))
+                .font(typography.settingsCaption)
                 .foregroundStyle(theme.tertiaryLabel)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)) { _ in
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+        ) { _ in
             displays = NookScreenLocator.connectedDisplays()
         }
     }

--- a/Sources/NookKit/App/Views/Settings/HotkeySettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/HotkeySettingsView.swift
@@ -16,28 +16,30 @@ struct SettingsShortcutRow: View {
     @ObservedObject var appState: AppState
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
     @Environment(\.nookHostBranding) private var branding
     @State private var isRecording = false
     @State private var eventMonitor: Any?
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center, spacing: metrics.settingsGroupSpacing) {
             Image(systemName: "keyboard")
-                .font(.system(size: 11, weight: .semibold))
+                .font(typography.settingsEmphasis)
                 .foregroundStyle(theme.headerInactiveIcon)
-                .frame(width: 18)
+                .frame(width: metrics.settingsIconWidth)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: metrics.settingsTextSpacing) {
                 Text("Show \(branding.hostName)")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(theme.primaryLabel.opacity(0.95))
+                    .font(typography.settingsRowTitle)
+                    .foregroundStyle(theme.primaryLabel.opacity(metrics.settingsTitleEmphasisOpacity))
                 if let failure = appState.hotkeyRegistrationFailures[NookHotkeyIDs.toggle] {
                     Text(failure.message)
-                        .font(.system(size: 9, weight: .regular))
+                        .font(typography.settingsHint)
                         .foregroundStyle(Color.orange)
                 } else {
                     Text(isRecording ? "Press a shortcut — Esc to cancel" : "Global shortcut — click to change")
-                        .font(.system(size: 9, weight: .regular))
+                        .font(typography.settingsHint)
                         .foregroundStyle(theme.tertiaryLabel)
                 }
             }
@@ -47,14 +49,19 @@ struct SettingsShortcutRow: View {
             Button(action: toggleRecording) {
                 if isRecording {
                     Text("Listening…")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(theme.primaryLabel.opacity(0.9))
-                        .padding(.horizontal, 10)
-                        .frame(minHeight: 22)
-                        .background(theme.subtleFill.opacity(0.7), in: Capsule())
-                        .overlay(Capsule().stroke(theme.accent.opacity(0.6), lineWidth: 1))
+                        .font(typography.settingsFieldLabel)
+                        .foregroundStyle(theme.primaryLabel.opacity(metrics.settingsRecordingLabelOpacity))
+                        .padding(.horizontal, metrics.settingsRecordingHorizontalPadding)
+                        .frame(minHeight: metrics.settingsRecordingMinHeight)
+                        .background(theme.subtleFill.opacity(metrics.settingsRecordingFillOpacity), in: Capsule())
+                        .overlay(
+                            Capsule().stroke(
+                                theme.accent.opacity(metrics.settingsRecordingStrokeOpacity),
+                                lineWidth: metrics.settingsRecordingStrokeWidth
+                            )
+                        )
                 } else {
-                    HStack(spacing: 4) {
+                    HStack(spacing: metrics.shortcutKeyCapSpacing) {
                         ForEach(Array(appState.hotkey.displaySymbols.enumerated()), id: \.offset) { _, symbol in
                             ShortcutKeySquircle(symbol: symbol)
                         }
@@ -63,9 +70,12 @@ struct SettingsShortcutRow: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, metrics.settingsRowVerticalPadding)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Show \(branding.hostName) shortcut, currently \(appState.hotkey.displaySymbols.joined(separator: " "))")
+        .accessibilityLabel(
+            "Show \(branding.hostName) shortcut, "
+                + "currently \(appState.hotkey.displaySymbols.joined(separator: " "))"
+        )
         .accessibilityHint("Activates to record a new shortcut")
         .onDisappear { stopRecording() }
     }
@@ -116,6 +126,9 @@ struct SettingsShortcutRow: View {
 struct SettingsHotkeyFailureRow: View {
     @ObservedObject var appState: AppState
 
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
+
     /// Failures for every shortcut except the show/hide toggle, sorted for stable order.
     private var staticFailures: [HotkeyRegistrationFailure] {
         appState.hotkeyRegistrationFailures
@@ -126,18 +139,18 @@ struct SettingsHotkeyFailureRow: View {
 
     var body: some View {
         if !staticFailures.isEmpty {
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: metrics.settingsFailureRowSpacing) {
                 ForEach(staticFailures, id: \.shortcutName) { failure in
-                    HStack(alignment: .center, spacing: 12) {
+                    HStack(alignment: .center, spacing: metrics.settingsGroupSpacing) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 11, weight: .semibold))
+                            .font(typography.settingsEmphasis)
                             .foregroundStyle(Color.orange)
-                            .frame(width: 18)
-                        VStack(alignment: .leading, spacing: 2) {
+                            .frame(width: metrics.settingsIconWidth)
+                        VStack(alignment: .leading, spacing: metrics.settingsTextSpacing) {
                             Text(failure.shortcutName)
-                                .font(.system(size: 11, weight: .medium))
+                                .font(typography.settingsRowTitle)
                             Text(failure.message)
-                                .font(.system(size: 9, weight: .regular))
+                                .font(typography.settingsHint)
                                 .foregroundStyle(Color.orange)
                         }
                         Spacer(minLength: 8)
@@ -146,7 +159,7 @@ struct SettingsHotkeyFailureRow: View {
                     .accessibilityLabel("\(failure.shortcutName) shortcut unavailable: \(failure.message)")
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, metrics.settingsRowVerticalPadding)
         }
     }
 }

--- a/Sources/NookKit/App/Views/Settings/SettingsCommonViews.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsCommonViews.swift
@@ -13,16 +13,24 @@ struct ShortcutKeySquircle: View {
     let symbol: String
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     var body: some View {
         Text(symbol)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(theme.primaryLabel.opacity(0.92))
-            .frame(minWidth: 24, minHeight: 22)
-            .background(theme.subtleFill.opacity(0.55), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .font(typography.settingsRowTitle)
+            .foregroundStyle(theme.primaryLabel.opacity(metrics.shortcutKeyCapLabelOpacity))
+            .frame(minWidth: metrics.shortcutKeyCapMinWidth, minHeight: metrics.shortcutKeyCapMinHeight)
+            .background(
+                theme.subtleFill.opacity(metrics.shortcutKeyCapFillOpacity),
+                in: RoundedRectangle(cornerRadius: metrics.shortcutKeyCapCornerRadius, style: .continuous)
+            )
             .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(theme.subtleStroke.opacity(0.35), lineWidth: 1)
+                RoundedRectangle(cornerRadius: metrics.shortcutKeyCapCornerRadius, style: .continuous)
+                    .stroke(
+                        theme.subtleStroke.opacity(metrics.shortcutKeyCapStrokeOpacity),
+                        lineWidth: metrics.shortcutKeyCapStrokeWidth
+                    )
             )
     }
 }
@@ -31,6 +39,8 @@ public struct SettingsSectionLabel: View {
     let title: String
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     public init(_ title: String) {
         self.title = title
@@ -38,8 +48,8 @@ public struct SettingsSectionLabel: View {
 
     public var body: some View {
         Text(title.uppercased())
-            .font(.system(size: 9, weight: .semibold))
+            .font(typography.settingsSectionLabel)
             .foregroundStyle(theme.quaternaryLabel)
-            .tracking(0.42)
+            .tracking(metrics.settingsSectionLabelTracking)
     }
 }

--- a/Sources/NookKit/App/Views/Settings/SettingsDataCommandRow.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsDataCommandRow.swift
@@ -62,19 +62,19 @@ struct SettingsDataCommandRow: View {
 
     private var iconTint: Color {
         switch style {
-        case .standard:
-            isHovering ? theme.accent : theme.headerInactiveIcon
-        case .destructive:
-            Color.red.opacity(0.92)
+            case .standard:
+                isHovering ? theme.accent : theme.headerInactiveIcon
+            case .destructive:
+                Color.red.opacity(0.92)
         }
     }
 
     private var titleTint: Color {
         switch style {
-        case .standard:
-            isHovering ? theme.accent : theme.primaryLabel
-        case .destructive:
-            Color.red.opacity(0.95)
+            case .standard:
+                isHovering ? theme.accent : theme.primaryLabel
+            case .destructive:
+                Color.red.opacity(0.95)
         }
     }
 }

--- a/Sources/NookKit/App/Views/Settings/SettingsDataCommandRow.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsDataCommandRow.swift
@@ -23,23 +23,25 @@ struct SettingsDataCommandRow: View {
     let action: () -> Void
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
     @State private var isHovering = false
 
     var body: some View {
         Button(action: action) {
-            HStack(alignment: .center, spacing: 10) {
+            HStack(alignment: .center, spacing: metrics.settingsRowSpacing) {
                 Image(systemName: icon)
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(typography.settingsCommandIcon)
                     .foregroundStyle(iconTint)
-                    .frame(width: 18)
+                    .frame(width: metrics.settingsIconWidth)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: metrics.settingsTextSpacing) {
                     Text(title)
-                        .font(.system(size: 12, weight: .regular))
+                        .font(typography.settingsCommandTitle)
                         .foregroundStyle(titleTint)
                         .multilineTextAlignment(.leading)
                     Text(subtitle)
-                        .font(.system(size: 11, weight: .regular))
+                        .font(typography.settingsRowDetail)
                         .foregroundStyle(theme.secondaryLabel)
                         .fixedSize(horizontal: false, vertical: true)
                         .multilineTextAlignment(.leading)
@@ -48,10 +50,10 @@ struct SettingsDataCommandRow: View {
                 Spacer(minLength: 0)
 
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(typography.settingsCommandChevron)
                     .foregroundStyle(isHovering ? iconTint : theme.quaternaryLabel)
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, metrics.settingsRowVerticalPadding)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -83,6 +85,8 @@ struct SettingsDataCommandRow: View {
 /// defaults.
 struct SettingsAboutCard: View {
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
     @Environment(\.nookHostBranding) private var branding
 
     /// Reads `CFBundleShortVersionString` from the running bundle. The SPM `swift run`
@@ -98,25 +102,25 @@ struct SettingsAboutCard: View {
         "A demo notch app built with OpenNook, an open-source framework for macOS notch apps."
 
     var body: some View {
-        HStack(alignment: .top, spacing: 10) {
+        HStack(alignment: .top, spacing: metrics.settingsRowSpacing) {
             branding.markView(
                 size: 14,
                 strokeWidth: 1.2,
                 color: theme.headerInactiveIcon
             )
-            .frame(width: 18)
+            .frame(width: metrics.settingsIconWidth)
 
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: metrics.settingsAboutTextSpacing) {
+                HStack(spacing: metrics.settingsInlineSpacing) {
                     Text(branding.hostName)
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(theme.primaryLabel.opacity(0.95))
+                        .font(typography.settingsEmphasis)
+                        .foregroundStyle(theme.primaryLabel.opacity(metrics.settingsTitleEmphasisOpacity))
                     Text("v\(version)")
-                        .font(.system(size: 10, weight: .regular, design: .monospaced))
+                        .font(typography.settingsVersionLabel)
                         .foregroundStyle(theme.tertiaryLabel)
                 }
                 Text(branding.hostTagline ?? Self.defaultTagline)
-                    .font(.system(size: 10, weight: .regular))
+                    .font(typography.settingsCaption)
                     .foregroundStyle(theme.secondaryLabel)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/Sources/NookKit/App/Views/Settings/SettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsView.swift
@@ -22,6 +22,7 @@ struct SettingsView: View {
     let onResetAllSettings: () -> Void
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeMetrics) private var metrics
 
     /// Curve-derived leading/trailing insets from the chrome. Matching them here aligns the
     /// section labels and rows with the top bar's leading cluster on a notched display.
@@ -56,7 +57,7 @@ struct SettingsView: View {
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: metrics.settingsSectionSpacing) {
                 section("Appearance") {
                     NookAppearanceSettingsSection(appState: appState)
                 }
@@ -66,7 +67,7 @@ struct SettingsView: View {
                 }
 
                 section("Shortcut & nook") {
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: metrics.settingsGroupSpacing) {
                         SettingsShortcutRow(appState: appState)
                         if !appState.hotkeyRegistrationFailures.keys.filter({ $0 != NookHotkeyIDs.toggle }).isEmpty {
                             SettingsHotkeyFailureRow(appState: appState)
@@ -93,7 +94,7 @@ struct SettingsView: View {
                 }
 
                 section("Data") {
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: metrics.settingsGroupSpacing) {
                         SettingsDataCommandRow(
                             title: "Preview status banner",
                             subtitle: "Shows the transient message channel under the top bar",
@@ -119,7 +120,7 @@ struct SettingsView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.bottom, 14)
+            .padding(.bottom, metrics.settingsContentBottomPadding)
         }
         .frame(maxWidth: .infinity, maxHeight: settingsScrollMaxHeight, alignment: .leading)
     }
@@ -152,22 +153,20 @@ private struct SettingsDisclosureSection<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     @Environment(\.nookResolvedTheme) private var theme
-
-    /// Width of the leading icon gutter the top bar's home/lock/gear icons occupy (24×24).
-    /// The disclosure chevron centers in the same gutter so the arrows sit directly under
-    /// the top-left home icon, and the connector hairline runs down its middle.
-    private let iconGutter: CGFloat = 24
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        let iconGutter = metrics.settingsDisclosureGutter
+        VStack(alignment: .leading, spacing: metrics.settingsBlockSpacing) {
             Button {
                 withAnimation(.spring(response: 0.30, dampingFraction: 0.86)) {
                     isExpanded.toggle()
                 }
             } label: {
-                HStack(spacing: 6) {
+                HStack(spacing: metrics.settingsInlineSpacing) {
                     Image(systemName: "chevron.right")
-                        .font(.system(size: 8, weight: .bold))
+                        .font(typography.settingsDisclosureChevron)
                         .foregroundStyle(theme.quaternaryLabel)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
                         .frame(width: iconGutter)
@@ -179,17 +178,17 @@ private struct SettingsDisclosureSection<Content: View>: View {
             .buttonStyle(.plain)
 
             if isExpanded {
-                HStack(alignment: .top, spacing: 12) {
+                HStack(alignment: .top, spacing: metrics.settingsGroupSpacing) {
                     // Connector: a thin vertical rule that fills the content height, tying the
                     // indented items back to the header. Centered under the chevron gutter.
                     RoundedRectangle(cornerRadius: 0.5, style: .continuous)
-                        .fill(theme.subtleStroke.opacity(0.5))
-                        .frame(width: 1)
+                        .fill(theme.subtleStroke.opacity(metrics.settingsConnectorOpacity))
+                        .frame(width: metrics.settingsConnectorWidth)
 
                     content()
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(.leading, (iconGutter - 1) / 2)
+                .padding(.leading, (iconGutter - metrics.settingsConnectorWidth) / 2)
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }

--- a/Sources/NookKit/App/Views/Shared/HeaderIcon.swift
+++ b/Sources/NookKit/App/Views/Shared/HeaderIcon.swift
@@ -9,20 +9,23 @@ import SwiftUI
 
 /// Static header icon (no hover, no action) used by the persistent "Home" cluster.
 ///
-/// Mirrors `HeaderIcon`'s 11pt / 24×24 / `headerInactiveIcon` styling so the home glyph
-/// reads at the same minimal weight as the lock / gear / search icons on the right side
-/// of the topbar. The deliberately muted tone (vs. `primaryLabel`) keeps it as chrome
-/// rather than competing with whatever the user actually came to do.
+/// Mirrors `HeaderIcon`'s glyph font and frame styling (``NookChromeTypography/headerIcon``
+/// / ``NookChromeMetrics/headerIconSize``) so the home glyph reads at the same minimal
+/// weight as the lock / gear / search icons on the right side of the topbar. The
+/// deliberately muted tone (vs. `primaryLabel`) keeps it as chrome rather than competing
+/// with whatever the user actually came to do.
 struct StaticHeaderIcon: View {
     let systemName: String
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     var body: some View {
         Image(systemName: systemName)
-            .font(.system(size: 11, weight: .semibold))
+            .font(typography.headerIcon)
             .foregroundStyle(theme.headerInactiveIcon)
-            .frame(width: 24, height: 24)
+            .frame(width: metrics.headerIconSize, height: metrics.headerIconSize)
     }
 }
 
@@ -36,22 +39,34 @@ struct HeaderIcon: View {
     let action: () -> Void
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
     @State private var isHovering = false
 
     var body: some View {
         Button(action: action) {
             Image(systemName: systemName)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(isActive ? activeColor : (isHovering ? theme.primaryLabel.opacity(0.92) : theme.headerInactiveIcon))
-                .frame(width: 24, height: 24)
-                .background(isHovering ? theme.subtleFill : .clear, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .font(typography.headerIcon)
+                .foregroundStyle(foreground)
+                .frame(width: metrics.headerIconSize, height: metrics.headerIconSize)
+                .background(
+                    isHovering ? theme.subtleFill : .clear,
+                    in: RoundedRectangle(cornerRadius: metrics.headerIconCornerRadius, style: .continuous)
+                )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .stroke(isHovering ? theme.subtleStroke : .clear, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: metrics.headerIconCornerRadius, style: .continuous)
+                        .stroke(isHovering ? theme.subtleStroke : .clear, lineWidth: metrics.headerIconStrokeWidth)
                 )
         }
         .buttonStyle(.plain)
         .help(help)
         .onHover { isHovering = $0 }
+    }
+
+    /// Active state wins; otherwise the glyph lifts to the emphasized primary label on
+    /// hover and rests on the muted inactive tone.
+    private var foreground: Color {
+        if isActive { return activeColor }
+        return isHovering ? theme.primaryLabel.opacity(metrics.headerIconHoverLabelOpacity) : theme.headerInactiveIcon
     }
 }

--- a/Sources/NookKit/App/Views/Shared/NookTransientStatusBanner.swift
+++ b/Sources/NookKit/App/Views/Shared/NookTransientStatusBanner.swift
@@ -16,18 +16,20 @@ struct NookTransientStatusBanner: View {
     let theme: NookResolvedTheme
 
     @Environment(\.nookChromeLabels) private var labels
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
 
     var body: some View {
         if let status = appState.status {
-            HStack(alignment: .top, spacing: 8) {
+            HStack(alignment: .top, spacing: metrics.bannerRowSpacing) {
                 Image(systemName: status.severity.systemImage)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(typography.bannerSeverityGlyph)
                     .foregroundStyle(theme.accent)
-                    .padding(.top, 1)
+                    .padding(.top, metrics.bannerSeverityGlyphTopInset)
 
                 Text(status.message)
-                    .font(.system(size: 10.5, weight: .medium))
-                    .foregroundStyle(theme.primaryLabel.opacity(0.92))
+                    .font(typography.bannerMessage)
+                    .foregroundStyle(theme.primaryLabel.opacity(metrics.bannerMessageLabelOpacity))
                     .fixedSize(horizontal: false, vertical: true)
 
                 Spacer(minLength: 0)
@@ -36,23 +38,26 @@ struct NookTransientStatusBanner: View {
                     appState.status = nil
                 } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 9, weight: .bold))
+                        .font(typography.bannerDismissGlyph)
                         .foregroundStyle(theme.tertiaryLabel)
-                        .frame(width: 18, height: 18)
+                        .frame(width: metrics.bannerDismissButtonSize, height: metrics.bannerDismissButtonSize)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help(labels.dismissHelp)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 7)
+            .padding(.horizontal, metrics.bannerContentHorizontalPadding)
+            .padding(.vertical, metrics.bannerContentVerticalPadding)
             .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                RoundedRectangle(cornerRadius: metrics.bannerCornerRadius, style: .continuous)
                     .fill(theme.subtleFill)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                    .stroke(theme.subtleStroke.opacity(0.65), lineWidth: 0.5)
+                RoundedRectangle(cornerRadius: metrics.bannerCornerRadius, style: .continuous)
+                    .stroke(
+                        theme.subtleStroke.opacity(metrics.bannerStrokeOpacity),
+                        lineWidth: metrics.bannerStrokeWidth
+                    )
             )
             .transition(
                 .asymmetric(

--- a/Sources/NookKit/App/Views/Shared/SettingActionLine.swift
+++ b/Sources/NookKit/App/Views/Shared/SettingActionLine.swift
@@ -18,6 +18,8 @@ public struct SettingActionLine: View {
     let action: () -> Void
 
     @Environment(\.nookResolvedTheme) private var theme
+    @Environment(\.nookChromeTypography) private var typography
+    @Environment(\.nookChromeMetrics) private var metrics
     @State private var isHovering = false
 
     public init(
@@ -36,26 +38,26 @@ public struct SettingActionLine: View {
 
     public var body: some View {
         Button(action: action) {
-            HStack(alignment: .top, spacing: 10) {
+            HStack(alignment: .top, spacing: metrics.settingsRowSpacing) {
                 Image(systemName: icon)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(typography.settingsEmphasis)
                     .foregroundStyle(isHovering ? accent : theme.headerInactiveIcon)
-                    .frame(width: 18)
+                    .frame(width: metrics.settingsIconWidth)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: metrics.settingsTextSpacing) {
                     Text(title)
-                        .font(.system(size: 12, weight: .regular))
+                        .font(typography.settingsCommandTitle)
                         .foregroundStyle(isHovering ? accent : theme.primaryLabel)
 
                     Text(detail)
-                        .font(.system(size: 11, weight: .regular))
+                        .font(typography.settingsRowDetail)
                         .foregroundStyle(theme.secondaryLabel)
                         .lineLimit(2)
                 }
 
                 Spacer(minLength: 0)
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, metrics.settingsRowVerticalPadding)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Tests/NookKitTests/NookChromeStyleTests.swift
+++ b/Tests/NookKitTests/NookChromeStyleTests.swift
@@ -164,6 +164,106 @@ final class NookChromeStyleTests: XCTestCase {
         XCTAssertEqual(configuration.typography.topBarLabel, .system(size: 13, weight: .bold))
     }
 
+    // MARK: - Full-sweep defaults (components, placeholder, settings)
+
+    /// The component, placeholder, and Settings font roles default to today's fonts.
+    func testFullSweepTypographyDefaultsReproduceFramework() {
+        let typography = NookChromeTypography.default
+        // Components
+        XCTAssertEqual(typography.shelfDropZoneIcon, .system(size: 24, weight: .light))
+        XCTAssertEqual(typography.shelfCaption, .system(size: 11))
+        XCTAssertEqual(typography.shelfHeaderLabel, .system(size: 11, weight: .medium))
+        XCTAssertEqual(typography.shelfChipLabel, .system(size: 10, weight: .medium))
+        XCTAssertEqual(typography.shelfFallbackGlyph, .system(size: 30, weight: .light))
+        XCTAssertEqual(typography.shelfRemoveGlyph, .system(size: 13))
+        XCTAssertEqual(typography.activityIcon, .system(size: 24, weight: .medium))
+        XCTAssertEqual(typography.activityTitle, .system(size: 13, weight: .semibold))
+        XCTAssertEqual(typography.activitySubtitle, .system(size: 11))
+        XCTAssertEqual(typography.volumeGlyph, .system(size: 11, weight: .semibold))
+        // Placeholder
+        XCTAssertEqual(typography.placeholderTitle, .system(size: 14, weight: .medium))
+        XCTAssertEqual(typography.placeholderBody, .system(size: 11, weight: .regular))
+        // Settings
+        XCTAssertEqual(typography.settingsSectionLabel, .system(size: 9, weight: .semibold))
+        XCTAssertEqual(typography.settingsHint, .system(size: 9, weight: .regular))
+        XCTAssertEqual(typography.settingsCaption, .system(size: 10, weight: .regular))
+        XCTAssertEqual(typography.settingsVersionLabel, .system(size: 10, weight: .regular, design: .monospaced))
+        XCTAssertEqual(typography.settingsFieldLabel, .system(size: 10, weight: .medium))
+        XCTAssertEqual(typography.settingsCommandChevron, .system(size: 10, weight: .bold))
+        XCTAssertEqual(typography.settingsRowDetail, .system(size: 11, weight: .regular))
+        XCTAssertEqual(typography.settingsRowTitle, .system(size: 11, weight: .medium))
+        XCTAssertEqual(typography.settingsEmphasis, .system(size: 11, weight: .semibold))
+        XCTAssertEqual(typography.settingsCommandTitle, .system(size: 12, weight: .regular))
+        XCTAssertEqual(typography.settingsCommandIcon, .system(size: 12, weight: .semibold))
+        XCTAssertEqual(typography.settingsDisclosureChevron, .system(size: 8, weight: .bold))
+    }
+
+    /// The component, placeholder, and Settings metric roles default to today's values.
+    func testFullSweepMetricsDefaultsReproduceFramework() {
+        let metrics = NookChromeMetrics.default
+        // Components - shelf
+        XCTAssertEqual(metrics.shelfContentSpacing, 8)
+        XCTAssertEqual(metrics.shelfRootVerticalPadding, 6)
+        XCTAssertEqual(metrics.shelfDropZoneVerticalPadding, 28)
+        XCTAssertEqual(metrics.shelfDropZoneCornerRadius, 12)
+        XCTAssertEqual(metrics.shelfDropZoneStrokeWidth, 1)
+        XCTAssertEqual(metrics.shelfHeaderSpacing, 10)
+        XCTAssertEqual(metrics.shelfChipSpacing, 4)
+        XCTAssertEqual(metrics.shelfChipWidth, 72)
+        XCTAssertEqual(metrics.shelfChipPadding, 8)
+        XCTAssertEqual(metrics.shelfChipCornerRadius, 10)
+        XCTAssertEqual(metrics.shelfIconSize, 34)
+        XCTAssertEqual(metrics.shelfRowVerticalPadding, 2)
+        // Components - activity + volume
+        XCTAssertEqual(metrics.activityCardSpacing, 12)
+        XCTAssertEqual(metrics.activityIconWidth, 30)
+        XCTAssertEqual(metrics.activityTextSpacing, 2)
+        XCTAssertEqual(metrics.activityCardVerticalPadding, 16)
+        XCTAssertEqual(metrics.activityCardHorizontalPadding, 8)
+        XCTAssertEqual(metrics.volumeGlyphOpacity, 0.85)
+        // Placeholder
+        XCTAssertEqual(metrics.placeholderStackSpacing, 10)
+        XCTAssertEqual(metrics.placeholderMarkSize, 28)
+        XCTAssertEqual(metrics.placeholderMarkStrokeWidth, 2)
+        XCTAssertEqual(metrics.placeholderVerticalPadding, 40)
+        // Settings - spacing
+        XCTAssertEqual(metrics.settingsSectionSpacing, 16)
+        XCTAssertEqual(metrics.settingsGroupSpacing, 12)
+        XCTAssertEqual(metrics.settingsRowSpacing, 10)
+        XCTAssertEqual(metrics.settingsBlockSpacing, 10)
+        XCTAssertEqual(metrics.settingsFieldSpacing, 5)
+        XCTAssertEqual(metrics.settingsTextSpacing, 2)
+        XCTAssertEqual(metrics.settingsAboutTextSpacing, 3)
+        XCTAssertEqual(metrics.settingsInlineSpacing, 6)
+        XCTAssertEqual(metrics.settingsContentBottomPadding, 14)
+        XCTAssertEqual(metrics.settingsRowVerticalPadding, 4)
+        // Settings - dims + opacities
+        XCTAssertEqual(metrics.settingsIconWidth, 18)
+        XCTAssertEqual(metrics.settingsDisclosureGutter, 24)
+        XCTAssertEqual(metrics.settingsSectionLabelTracking, 0.42)
+        XCTAssertEqual(metrics.settingsConnectorWidth, 1)
+        XCTAssertEqual(metrics.settingsConnectorOpacity, 0.5)
+        XCTAssertEqual(metrics.settingsAccentSwatchSize, 18)
+        XCTAssertEqual(metrics.settingsAccentSwatchStrokeWidth, 1.5)
+        XCTAssertEqual(metrics.settingsAccentSwatchSelectedOpacity, 0.85)
+        XCTAssertEqual(metrics.shortcutKeyCapMinWidth, 24)
+        XCTAssertEqual(metrics.shortcutKeyCapMinHeight, 22)
+        XCTAssertEqual(metrics.shortcutKeyCapCornerRadius, 6)
+        XCTAssertEqual(metrics.shortcutKeyCapLabelOpacity, 0.92)
+        XCTAssertEqual(metrics.shortcutKeyCapFillOpacity, 0.55)
+        XCTAssertEqual(metrics.shortcutKeyCapStrokeOpacity, 0.35)
+        XCTAssertEqual(metrics.shortcutKeyCapStrokeWidth, 1)
+        XCTAssertEqual(metrics.shortcutKeyCapSpacing, 4)
+        XCTAssertEqual(metrics.settingsRecordingHorizontalPadding, 10)
+        XCTAssertEqual(metrics.settingsRecordingMinHeight, 22)
+        XCTAssertEqual(metrics.settingsRecordingFillOpacity, 0.7)
+        XCTAssertEqual(metrics.settingsRecordingStrokeOpacity, 0.6)
+        XCTAssertEqual(metrics.settingsRecordingStrokeWidth, 1)
+        XCTAssertEqual(metrics.settingsTitleEmphasisOpacity, 0.95)
+        XCTAssertEqual(metrics.settingsRecordingLabelOpacity, 0.9)
+        XCTAssertEqual(metrics.settingsFailureRowSpacing, 4)
+    }
+
     // MARK: - Motion
 
     func testMotionDefaultsAndConfigurable() {

--- a/Tests/NookKitTests/NookChromeStyleTests.swift
+++ b/Tests/NookKitTests/NookChromeStyleTests.swift
@@ -9,8 +9,9 @@ import SwiftUI
 import XCTest
 @testable import NookKit
 
-/// Seam C - chrome labels, layout metrics, in-panel motion, and the status/severity
-/// channel. Defaults reproduce today's chrome; the configuration carries host overrides.
+/// Seam C - chrome labels, layout metrics, typography, in-panel motion, and the
+/// status/severity channel. Defaults reproduce today's chrome; the configuration carries
+/// host overrides.
 @MainActor
 final class NookChromeStyleTests: XCTestCase {
     // MARK: - Status + severity
@@ -89,6 +90,78 @@ final class NookChromeStyleTests: XCTestCase {
         configuration.metrics.compactSlotSize = 28
         XCTAssertEqual(configuration.metrics.edgePadding, 12)
         XCTAssertEqual(configuration.metrics.compactSlotSize, 28)
+    }
+
+    /// The element-level metrics added for the styling-token pass default to today's
+    /// baked-in values, so a plain configuration renders pixel-identically.
+    func testExtendedMetricsDefaultsReproduceFramework() {
+        let metrics = NookChromeMetrics.default
+        // Expanded surface + top bar
+        XCTAssertEqual(metrics.expandedColumnSpacing, 8)
+        XCTAssertEqual(metrics.topBarItemSpacing, 8)
+        XCTAssertEqual(metrics.leadingClusterSpacing, 6)
+        XCTAssertEqual(metrics.trailingClusterSpacing, 4)
+        // Header icons
+        XCTAssertEqual(metrics.headerIconSize, 24)
+        XCTAssertEqual(metrics.headerIconCornerRadius, 7)
+        XCTAssertEqual(metrics.headerIconStrokeWidth, 1)
+        XCTAssertEqual(metrics.headerIconHoverLabelOpacity, 0.92)
+        // Leading brand mark
+        XCTAssertEqual(metrics.brandMarkSize, 11)
+        XCTAssertEqual(metrics.brandMarkStrokeWidth, 1.1)
+        XCTAssertEqual(metrics.brandMarkOpacity, 0.92)
+        // Compact pill
+        XCTAssertEqual(metrics.compactLeadingGlyphOpacity, 0.88)
+        XCTAssertEqual(metrics.compactTrailingMarkSize, 11)
+        XCTAssertEqual(metrics.compactTrailingMarkStrokeWidth, 1.1)
+        XCTAssertEqual(metrics.compactTrailingMarkOpacity, 0.82)
+        // Status banner
+        XCTAssertEqual(metrics.bannerRowSpacing, 8)
+        XCTAssertEqual(metrics.bannerCornerRadius, 10)
+        XCTAssertEqual(metrics.bannerContentHorizontalPadding, 10)
+        XCTAssertEqual(metrics.bannerContentVerticalPadding, 7)
+        XCTAssertEqual(metrics.bannerSeverityGlyphTopInset, 1)
+        XCTAssertEqual(metrics.bannerDismissButtonSize, 18)
+        XCTAssertEqual(metrics.bannerMessageLabelOpacity, 0.92)
+        XCTAssertEqual(metrics.bannerStrokeOpacity, 0.65)
+        XCTAssertEqual(metrics.bannerStrokeWidth, 0.5)
+    }
+
+    func testExtendedMetricsAreHostConfigurable() {
+        var configuration = NookConfiguration()
+        configuration.metrics.headerIconCornerRadius = 10
+        configuration.metrics.bannerCornerRadius = 14
+        XCTAssertEqual(configuration.metrics.headerIconCornerRadius, 10)
+        XCTAssertEqual(configuration.metrics.bannerCornerRadius, 14)
+        XCTAssertNotEqual(configuration.metrics, .default)
+    }
+
+    // MARK: - Typography
+
+    /// The chrome font roles default to today's baked-in fonts, so a plain configuration
+    /// renders pixel-identically. Pins each role so a future drift is caught.
+    func testTypographyDefaultsReproduceFramework() {
+        let typography = NookChromeTypography.default
+        XCTAssertEqual(typography.headerIcon, .system(size: 11, weight: .semibold))
+        XCTAssertEqual(typography.topBarLabel, .system(size: 11, weight: .regular))
+        XCTAssertEqual(typography.breadcrumbChevron, .system(size: 8, weight: .bold))
+        XCTAssertEqual(typography.switcherChevron, .system(size: 7, weight: .semibold))
+        XCTAssertEqual(typography.compactLeadingGlyph, .system(size: 10, weight: .semibold))
+        XCTAssertEqual(typography.bannerSeverityGlyph, .system(size: 11, weight: .semibold))
+        XCTAssertEqual(typography.bannerMessage, .system(size: 10.5, weight: .medium))
+        XCTAssertEqual(typography.bannerDismissGlyph, .system(size: 9, weight: .bold))
+
+        XCTAssertEqual(NookConfiguration().typography, .default)
+    }
+
+    func testTypographyDefaultsAndConfigurable() {
+        XCTAssertEqual(NookConfiguration().typography, .default)
+        XCTAssertEqual(NookChromeTypography.default, NookChromeTypography())
+
+        var configuration = NookConfiguration()
+        configuration.typography.topBarLabel = .system(size: 13, weight: .bold)
+        XCTAssertNotEqual(configuration.typography, .default)
+        XCTAssertEqual(configuration.typography.topBarLabel, .system(size: 13, weight: .bold))
     }
 
     // MARK: - Motion

--- a/site/src/content/docs/guides/chrome-customization.mdx
+++ b/site/src/content/docs/guides/chrome-customization.mdx
@@ -209,13 +209,19 @@ insets](/guides/layout-and-insets/) and `Examples/LayoutNook/main.swift`.
 
 ### Typography
 
-`NookChromeTypography` sets the fonts for the chrome's own text and glyphs - the
-top bar, the compact pill, and the status banner. Each role is a `Font`; defaults
-reproduce today's sizes and weights. Because the framework defaults carry no
-explicit design, the resolved `fontDesign` (see [Theming](/guides/theming/)) still
-cascades over them - set `.rounded` once on the theme and every chrome role
-follows. This restyles the *chrome's* type only; a registered home view, custom
-Settings, or trailing items control their own fonts.
+`NookChromeTypography` sets the fonts for the framework's own text and glyphs.
+Each role is a `Font`; defaults reproduce today's sizes and weights. Because the
+framework defaults carry no explicit design, the resolved `fontDesign` (see
+[Theming](/guides/theming/)) still cascades over them - set `.rounded` once on the
+theme and every role follows. This restyles the *framework's* type only; a
+registered home view, custom Settings, or trailing items control their own fonts.
+
+Roles cover the chrome (top bar, compact pill, status banner) shown below, plus
+the placeholder home, the built-in Settings panel (rows, pickers, the shortcut key
+cap, the disclosure section), and the optional `NookComponents` shelf, activity
+card, and volume glyph - so every framework-drawn surface is restylable. The same
+applies to `NookChromeMetrics`, whose fields extend past the chrome into those
+surfaces' dimensions, radii, spacing, and emphasis opacities.
 
 ```swift
 configuration.typography.headerIcon = .system(size: 11, weight: .semibold)  // lock / gear / home glyphs

--- a/site/src/content/docs/guides/chrome-customization.mdx
+++ b/site/src/content/docs/guides/chrome-customization.mdx
@@ -154,9 +154,9 @@ Like `preferenceDefaults`, it is host-process-global: a single-module host sets
 it on `NookConfiguration`; a multi-module host sets it on
 `NookHostConfiguration.chromeBehavior`.
 
-## Labels, metrics, motion
+## Labels, metrics, typography, motion
 
-Three small value types tune the chrome's strings, fixed layout values, and
+Four small value types tune the chrome's strings, fixed layout values, fonts, and
 in-panel springs. Each defaults to a value that reproduces today's framework
 exactly, and each reaches the views through a chrome environment value, so a host
 sets only the fields it cares about.
@@ -179,8 +179,8 @@ the gear, and the banner's dismiss button.
 
 ### Metrics
 
-`NookChromeMetrics` exposes the few fixed point values that were previously baked
-into the views. Defaults reproduce today's layout:
+`NookChromeMetrics` exposes the fixed point values that were previously baked into
+the chrome views. Defaults reproduce today's layout:
 
 ```swift
 configuration.metrics.edgePadding = 8          // panel edge to content inset
@@ -189,10 +189,40 @@ configuration.metrics.breadcrumbMaxWidth = 140 // top-bar breadcrumb width befor
 configuration.metrics.topBarHeight = 24        // fixed height of the top bar icon row
 ```
 
+It also carries the element-level sizes, corner radii, spacing, and the opacity
+multipliers layered on the resolved palette - the values the top bar, header
+icons, compact pill, and status banner used to hardcode. A few of them (every
+field defaults to today's value, so set only what you want to change):
+
+```swift
+configuration.metrics.headerIconSize = 24          // lock / gear / home glyph frame
+configuration.metrics.headerIconCornerRadius = 7   // header-icon hover chip radius
+configuration.metrics.trailingClusterSpacing = 4   // gap between trailing items / lock / gear
+configuration.metrics.brandMarkOpacity = 0.92      // leading brand-mark emphasis
+configuration.metrics.bannerCornerRadius = 10      // status banner corner radius
+```
+
 `edgePadding` is distinct from `NookStyle.expandedContentInsets`; host home views
 should read the residual clearance through `nookContentInsets` rather than
 mirroring it with extra padding. See [Layout and content
 insets](/guides/layout-and-insets/) and `Examples/LayoutNook/main.swift`.
+
+### Typography
+
+`NookChromeTypography` sets the fonts for the chrome's own text and glyphs - the
+top bar, the compact pill, and the status banner. Each role is a `Font`; defaults
+reproduce today's sizes and weights. Because the framework defaults carry no
+explicit design, the resolved `fontDesign` (see [Theming](/guides/theming/)) still
+cascades over them - set `.rounded` once on the theme and every chrome role
+follows. This restyles the *chrome's* type only; a registered home view, custom
+Settings, or trailing items control their own fonts.
+
+```swift
+configuration.typography.headerIcon = .system(size: 11, weight: .semibold)  // lock / gear / home glyphs
+configuration.typography.topBarLabel = .system(size: 11, weight: .regular)  // title, breadcrumb, switcher label
+configuration.typography.compactLeadingGlyph = .system(size: 10, weight: .semibold)
+configuration.typography.bannerMessage = .system(size: 10.5, weight: .medium)
+```
 
 ### Motion
 


### PR DESCRIPTION
## Summary

Makes every font, size, corner radius, spacing, and opacity in the framework
chrome host-tunable through public tokens instead of inline literals. Colors were
already centralized in NookResolvedTheme; this does the same for type and
dimensions, so a host can restyle the chrome without forking.

## What changed

- New `NookChromeTypography`: font roles for the chrome's own text and glyphs, set
  via `NookConfiguration.typography`. The resolved `fontDesign` still cascades over
  the roles.
- Extended `NookChromeMetrics` with the element-level sizes, corner radii, spacing,
  and opacity multipliers that were previously baked into the views.
- These tokens are now read by the chrome (top bar, header icons, compact pill,
  status banner), the `NookComponents` add-ons (file shelf, activity card, volume
  glyph), the placeholder home, and the built-in Settings panel.

## Compatibility

Every token defaults to today's value, so a plain `NookApp.main { ... }` renders
identically. The change is additive and non-breaking.

A few intentionally-structural literals stay inline: the fixed severity and
destructive-action colors, the motion spring and offset magnitudes, the breadcrumb
gradient mask, and zero-floor spacers.

## Testing

- `swift build` clean
- `swift test --parallel`: 275 tests passing
- ASCII typography check, DocC build: green
