### PR TITLE
Move repository to athledev-labs and release 0.4.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or discussion
-    url: https://github.com/glendonC/opennook/discussions
+    url: https://github.com/athledev-labs/opennook/discussions
     about: For open-ended questions, design discussions, or "how do I...?" - use Discussions, not Issues.
   - name: Security vulnerability
-    url: https://github.com/glendonC/opennook/security/advisories/new
+    url: https://github.com/athledev-labs/opennook/security/advisories/new
     about: Please report security issues privately, not in public issues. See SECURITY.md.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-29
+
 ### Added
 
 - `NookChromeTypography` - a host-tunable token type for the framework's own
@@ -33,6 +35,9 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   public API only. (A few intentionally-structural literals stay inline: motion
   spring/offset magnitudes, the breadcrumb gradient mask, the fixed severity and
   destructive-action colors, and zero-floor spacers.)
+- The GitHub repository moved to [athledev-labs/opennook](https://github.com/athledev-labs/opennook).
+  Update your Swift package URL; GitHub redirects the old `glendonC/opennook` path
+  for a transition period.
 
 ## [0.3.1] - 2026-06-12
 
@@ -146,16 +151,17 @@ This is still 0.x: the public API is not frozen. Pin to a tag.
 
 ## [0.2.0] - 2026-05-23
 
-See the [v0.2.0 release](https://github.com/glendonC/opennook/releases) on
+See the [v0.2.0 release](https://github.com/athledev-labs/opennook/releases) on
 GitHub.
 
 ## [0.1.0] - 2026-05-22
 
 Initial public release. See the
-[v0.1.0 release](https://github.com/glendonC/opennook/releases) on GitHub.
+[v0.1.0 release](https://github.com/athledev-labs/opennook/releases) on GitHub.
 
-[Unreleased]: https://github.com/glendonC/opennook/compare/v0.3.1...HEAD
-[0.3.1]: https://github.com/glendonC/opennook/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/glendonC/opennook/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/glendonC/opennook/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/glendonC/opennook/releases/tag/v0.1.0
+[Unreleased]: https://github.com/athledev-labs/opennook/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/athledev-labs/opennook/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/athledev-labs/opennook/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/athledev-labs/opennook/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/athledev-labs/opennook/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/athledev-labs/opennook/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,7 +13,7 @@ Report unacceptable behavior to the project maintainer
 message or a [private security advisory][advisory]. All reports will be
 handled with discretion.
 
-[advisory]: https://github.com/glendonC/opennook/security/advisories/new
+[advisory]: https://github.com/athledev-labs/opennook/security/advisories/new
 
 Maintainers who do not follow or enforce the Code of Conduct in good faith
 may face temporary or permanent repercussions as determined by other

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OpenNook
 
-[![CI](https://github.com/glendonC/opennook/actions/workflows/ci.yml/badge.svg)](https://github.com/glendonC/opennook/actions/workflows/ci.yml)
+[![CI](https://github.com/athledev-labs/opennook/actions/workflows/ci.yml/badge.svg)](https://github.com/athledev-labs/opennook/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![License: MIT (NookSurface)](https://img.shields.io/badge/NookSurface-MIT-blue.svg)](LICENSE-MIT-NOOKSURFACE)
 [![Swift 5.9+](https://img.shields.io/badge/swift-5.9%2B-orange.svg)](https://swift.org)
 [![Platform: macOS 15+](https://img.shields.io/badge/platform-macOS%2015%2B-lightgrey.svg)](#requirements)
-[![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FglendonC%2Fopennook%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/glendonC/opennook)
-[![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FglendonC%2Fopennook%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/glendonC/opennook)
+[![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fathledev-labs%2Fopennook%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/athledev-labs/opennook)
+[![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fathledev-labs%2Fopennook%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/athledev-labs/opennook)
 
 **An open-source framework for building macOS notch apps.**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ release. Older tags are not patched.
 Please **do not** open a public issue for security problems.
 
 Use GitHub's private vulnerability reporting:
-<https://github.com/glendonC/opennook/security/advisories/new>
+<https://github.com/athledev-labs/opennook/security/advisories/new>
 
 Include:
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
         replacesTitle: false,
       },
       social: [
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/glendonC/opennook' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/athledev-labs/opennook' },
       ],
       editLink: { baseUrl: undefined },
       lastUpdated: false,

--- a/site/src/content/docs/guides/shipping.mdx
+++ b/site/src/content/docs/guides/shipping.mdx
@@ -39,7 +39,7 @@ suite through `NookModuleContext`. Keep your host product keys separate from
 
 ## Entitlements
 
-A copy-paste template lives at [`App/Nook.entitlements`](https://github.com/glendonC/opennook/blob/main/App/Nook.entitlements).
+A copy-paste template lives at [`App/Nook.entitlements`](https://github.com/athledev-labs/opennook/blob/main/App/Nook.entitlements).
 It includes the minimum for App Sandbox plus the features OpenNook expects:
 
 - `com.apple.security.app-sandbox`

--- a/site/src/content/docs/reference/api.mdx
+++ b/site/src/content/docs/reference/api.mdx
@@ -4,10 +4,10 @@ description: The public API surface of OpenNook, by module.
 ---
 
 OpenNook publishes its symbol-level DocC reference through
-[Swift Package Index](https://swiftpackageindex.com/glendonC/opennook),
+[Swift Package Index](https://swiftpackageindex.com/athledev-labs/opennook),
 regenerated on each tagged release, at:
 
-[https://swiftpackageindex.com/glendonC/opennook/documentation](https://swiftpackageindex.com/glendonC/opennook/documentation)
+[https://swiftpackageindex.com/athledev-labs/opennook/documentation](https://swiftpackageindex.com/athledev-labs/opennook/documentation)
 
 The map below is the maintained index of the public surface, grouped by module,
 with the guide that teaches each piece and the source file that defines it. The

--- a/site/src/content/docs/start/install.mdx
+++ b/site/src/content/docs/start/install.mdx
@@ -11,7 +11,7 @@ Swift 5.9 or later.
 In your `Package.swift`, add OpenNook to `dependencies`:
 
 ```swift
-.package(url: "https://github.com/glendonC/opennook", from: "0.2.0"),
+.package(url: "https://github.com/athledev-labs/opennook", from: "0.4.0"),
 ```
 
 Then add the products you need to your target's `dependencies`:
@@ -39,5 +39,5 @@ and `NookSurface`. `NookComponents` is opt-in.
 ## In Xcode
 
 File -> Add Package Dependencies, paste
-`https://github.com/glendonC/opennook`, and add the `NookApp` product
+`https://github.com/athledev-labs/opennook`, and add the `NookApp` product
 (and `NookComponents` if you want it) to your app target.

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-const repoUrl = 'https://github.com/glendonC/opennook';
+const repoUrl = 'https://github.com/athledev-labs/opennook';
 const docsUrl = '/start/introduction/';
 import '../styles/tokens.css';
 const carouselLines = [


### PR DESCRIPTION
## Summary
- Updates all repository URLs from `glendonC/opennook` to `athledev-labs/opennook` (README badges, docs site, security links, install guide).
- Cuts the 0.4.0 changelog entry (chrome typography/metrics tokens + org transfer note).
- Tag `v0.4.0` is already pushed on this commit.

## Test plan
- [x] CI on prior chrome-style-tokens commits
- [ ] Merge after checks pass

Made with [Cursor](https://cursor.com)