### PR TITLE
Add a host-injectable settings-section seam

### DIFF
--- a/Sources/NookKit/App/NookConfiguration.swift
+++ b/Sources/NookKit/App/NookConfiguration.swift
@@ -61,6 +61,12 @@ public struct NookConfiguration: Sendable {
     /// the built-in screen; the host view reads ``AppState`` via `@EnvironmentObject`.
     public var settings: (@Sendable @MainActor () -> AnyView)? = nil
 
+    /// Extra host sections appended to the framework's **built-in** Settings surface, rendered
+    /// below the framework groups (Appearance, Display, ...) and above About. Empty (the default)
+    /// leaves Settings unchanged. Ignored when ``settings`` fully replaces the built-in screen.
+    /// Use ``addSettingsSection(id:title:content:)`` to append one from a `@ViewBuilder`.
+    public var settingsSections: [NookSettingsSection] = []
+
     /// Top-bar configuration - leading cluster (title/icon), and the two visibility
     /// flags for the top bar and the Settings UI. Grouped so the related knobs
     /// travel together and future top-bar settings land here cleanly. See
@@ -224,6 +230,19 @@ public struct NookConfiguration: Sendable {
         @ViewBuilder _ content: @escaping @Sendable @MainActor () -> Content
     ) {
         settings = { AnyView(content()) }
+    }
+
+    /// Appends one host section to the framework's built-in Settings surface from a `@ViewBuilder`.
+    /// The section renders below the framework groups and above About, in the same collapsible
+    /// disclosure chrome. See ``NookSettingsSection``.
+    public mutating func addSettingsSection<Content: View & Sendable>(
+        id: String? = nil,
+        title: String,
+        @ViewBuilder content: @escaping @Sendable @MainActor () -> Content
+    ) {
+        settingsSections.append(
+            NookSettingsSection(id: id, title: title, content: content)
+        )
     }
 
     /// Registers host actions for the top bar's trailing cluster from a `@ViewBuilder`

--- a/Sources/NookKit/App/Views/ModuleRouterViews.swift
+++ b/Sources/NookKit/App/Views/ModuleRouterViews.swift
@@ -32,6 +32,7 @@ struct ModuleRouterExpandedView: View {
             theme: configuration.theme,
             home: configuration.home,
             settings: configuration.settings,
+            settingsSections: configuration.settingsSections,
             topBar: configuration.topBar,
             labels: configuration.labels,
             metrics: configuration.metrics,

--- a/Sources/NookKit/App/Views/NookExpandedView.swift
+++ b/Sources/NookKit/App/Views/NookExpandedView.swift
@@ -39,6 +39,10 @@ public struct NookExpandedView: View {
     /// See ``NookConfiguration/settings``.
     let settings: (@Sendable @MainActor () -> AnyView)?
 
+    /// Extra host sections appended to the framework's built-in Settings surface (ignored when
+    /// ``settings`` replaces it). See ``NookConfiguration/settingsSections``.
+    let settingsSections: [NookSettingsSection]
+
     /// The framework top bar's host-configurable surface - leading cluster, top-bar
     /// visibility, Settings visibility. See ``NookTopBarConfiguration``.
     let topBar: NookTopBarConfiguration
@@ -82,6 +86,7 @@ public struct NookExpandedView: View {
         },
         home: @escaping @Sendable @MainActor () -> AnyView = { AnyView(NookPlaceholderHomeView()) },
         settings: (@Sendable @MainActor () -> AnyView)? = nil,
+        settingsSections: [NookSettingsSection] = [],
         topBar: NookTopBarConfiguration = .default,
         labels: NookChromeLabels = .default,
         metrics: NookChromeMetrics = .default,
@@ -98,6 +103,7 @@ public struct NookExpandedView: View {
         self.theme = theme
         self.home = home
         self.settings = settings
+        self.settingsSections = settingsSections
         self.topBar = topBar
         self.labels = labels
         self.metrics = metrics
@@ -249,6 +255,7 @@ public struct NookExpandedView: View {
         } else {
             SettingsView(
                 appState: appState,
+                hostSections: settingsSections,
                 onToggleKeepOpen: toggleKeepOpen,
                 onResetAllSettings: resetAllSettings
             )

--- a/Sources/NookKit/App/Views/Settings/NookSettingsSection.swift
+++ b/Sources/NookKit/App/Views/Settings/NookSettingsSection.swift
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Glendon Chin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy is included at /LICENSE in the repository root.
+
+import SwiftUI
+
+/// A host-supplied section injected into the framework's built-in Settings surface. It is
+/// rendered below the framework's own groups (Appearance, Display, ...) and above About,
+/// wrapped in the same collapsible disclosure, connector hairline, and section label as the
+/// built-in groups (see ``SettingsSectionLabel``).
+///
+/// Register sections through ``NookConfiguration/addSettingsSection(id:title:content:)`` (or by
+/// assigning ``NookConfiguration/settingsSections`` directly). The content is rendered inside the
+/// same environment as the framework sections, so it can read ``AppState`` via `@EnvironmentObject`
+/// and the resolved palette via `@Environment(\.nookResolvedTheme)`.
+///
+/// > Note: These sections are shown only by the built-in Settings screen. A host that fully
+/// > replaces Settings via ``NookConfiguration/settings`` owns its own layout and these are ignored.
+///
+/// `Sendable`: it is carried by a `Sendable` ``NookConfiguration``, and the content closure is
+/// `@Sendable @MainActor` like every other chrome content closure (`home`, `settings`).
+public struct NookSettingsSection: Identifiable, Sendable {
+    /// Stable identity for the disclosure state and `ForEach`. Defaults to ``title``; set an
+    /// explicit id if two sections could share a title. Must not collide with a framework section
+    /// title ("Appearance", "Display", "Shortcut & nook", "Data", "About"), which would toggle both.
+    public let id: String
+
+    /// The section header label (uppercased by the chrome).
+    public let title: String
+
+    /// Builds the section body, shown when the disclosure is expanded.
+    public let content: @Sendable @MainActor () -> AnyView
+
+    public init<Content: View & Sendable>(
+        id: String? = nil,
+        title: String,
+        @ViewBuilder content: @escaping @Sendable @MainActor () -> Content
+    ) {
+        self.id = id ?? title
+        self.title = title
+        self.content = { AnyView(content()) }
+    }
+}

--- a/Sources/NookKit/App/Views/Settings/SettingsView.swift
+++ b/Sources/NookKit/App/Views/Settings/SettingsView.swift
@@ -18,6 +18,8 @@ import SwiftUI
 /// no card fills, no rules.
 struct SettingsView: View {
     @ObservedObject var appState: AppState
+    /// Host-supplied sections rendered below the framework groups and above About.
+    let hostSections: [NookSettingsSection]
     let onToggleKeepOpen: () -> Void
     let onResetAllSettings: () -> Void
 
@@ -112,6 +114,12 @@ struct SettingsView: View {
                             style: .standard,
                             action: onResetAllSettings
                         )
+                    }
+                }
+
+                ForEach(hostSections) { hostSection in
+                    section(hostSection.title) {
+                        hostSection.content()
                     }
                 }
 


### PR DESCRIPTION
## What

Adds `NookSettingsSection` and `NookConfiguration.settingsSections` (plus an `addSettingsSection(id:title:content:)` convenience) so a host app can append its own section to the framework's built-in Settings surface, without having to fully replace it via `setSettings`.

## Why

Today a host can only *replace* the whole Settings screen (`NookConfiguration.settings`), which forfeits the framework's Appearance/Display/Shortcut/Data/About groups (their subviews are internal). Appending a section lets a host add, e.g., an "AI" entry alongside the built-in groups.

## How

Host sections thread through the existing single funnel: `NookConfiguration.settingsSections` -> `ModuleRouterViews` -> `NookExpandedView` -> `SettingsView`, and render through the same collapsible `section(_:)` helper (disclosure header, connector hairline, section label) between Data and About. Fully additive: the new field defaults to empty and every existing caller is unchanged. Ignored when `settings` replaces the surface.

`swift build` green; swift-format + ASCII checks pass on the touched files.